### PR TITLE
fix ddesktopservices_linux.cpp include header file error

### DIFF
--- a/src/util/ddesktopservices_linux.cpp
+++ b/src/util/ddesktopservices_linux.cpp
@@ -22,7 +22,7 @@
 #include <QDebug>
 #include <QFile>
 #include <QMediaPlayer>
-#include <QGSettings>
+#include <QGSettings/QGSettings>
 
 DWIDGET_BEGIN_NAMESPACE
 


### PR DESCRIPTION
The gsettings header file is located in GSettings/GSettings, 
but the file is using <GSettings>, which causes the search 
to not include headers, so change to <GSettings/GSettings>