### PR TITLE
fix: always show menu button

### DIFF
--- a/src/widgets/dtitlebar.cpp
+++ b/src/widgets/dtitlebar.cpp
@@ -322,9 +322,6 @@ void DTitlebarPrivate::updateButtonsState(Qt::WindowFlags type)
     bool showClose = (type.testFlag(Qt::WindowCloseButtonHint) || forceShow) && !forceHide;
     closeButton->setVisible(showClose);
 
-    bool showOption = (type.testFlag(Qt::WindowSystemMenuHint) || forceShow) && !isFullscreen;
-    optionButton->setVisible(showOption);
-
     buttonArea->adjustSize();
     buttonArea->resize(buttonArea->size());
 
@@ -335,8 +332,6 @@ void DTitlebarPrivate::updateButtonsState(Qt::WindowFlags type)
 
 void DTitlebarPrivate::updateButtonsFunc()
 {
-    optionButton->setDisabled(disableFlags.testFlag(Qt::WindowSystemMenuHint));
-
     if (!targetWindowHandle) {
         return;
     }
@@ -1012,6 +1007,30 @@ void DTitlebar::resize(int w, int h)
 void DTitlebar::resize(const QSize &sz)
 {
     DTitlebar::resize(sz.width(), sz.height());
+}
+
+bool DTitlebar::menuIsVisible() const
+{
+    D_DC(DTitlebar);
+    return !d->optionButton->isVisible();
+}
+
+void DTitlebar::setMenuVisible(bool visible)
+{
+    D_D(DTitlebar);
+    d->optionButton->setVisible(visible);
+}
+
+bool DTitlebar::menuIsDisabled() const
+{
+    D_DC(DTitlebar);
+    return !d->optionButton->isEnabled();
+}
+
+void DTitlebar::setMenuDisabled(bool disabled)
+{
+    D_D(DTitlebar);
+    d->optionButton->setDisabled(disabled);
 }
 
 

--- a/src/widgets/dtitlebar.h
+++ b/src/widgets/dtitlebar.h
@@ -54,6 +54,12 @@ public:
     void resize(int width, int height);
     void resize(const QSize &);
 
+    bool menuIsVisible() const;
+    void setMenuVisible(bool visible);
+
+    bool menuIsDisabled() const;
+    void setMenuDisabled(bool disabled);
+
     void setDisableFlags(Qt::WindowFlags flags);
     Qt::WindowFlags disableFlags() const;
 Q_SIGNALS:


### PR DESCRIPTION
Notice that WindowSystemMenuHint not mean user menu, but mean Close
Button, Do not use it in DTitlebar. See blow link for more:

https://doc.qt.io/qt-5/qt.html#WindowType-enum

Change-Id: Ifad262ea190c1fb4778edfd0b525ef0c04e0e4ff