### PR TITLE
fix: hide the non-window type window titlebar menu button on initialize

### DIFF
--- a/src/widgets/dtitlebar.cpp
+++ b/src/widgets/dtitlebar.cpp
@@ -550,6 +550,12 @@ DTitlebar::DTitlebar(QWidget *parent) :
 
     D_D(DTitlebar);
     d->init();
+
+    // 默认只在普通窗口中显示窗口菜单按钮
+    if (parent && parent->window()->windowType() != Qt::Window) {
+        d->optionButton->hide();
+    }
+
     d->buttonArea->adjustSize();
     d->buttonArea->resize(d->buttonArea->size());
     d->titlePadding->setFixedSize(d->buttonArea->size());


### PR DESCRIPTION
https://github.com/linuxdeepin/internal-discussion/issues/1625

默认时只在普通类型窗口的标题栏上显示菜单按钮