### PR TITLE
feat: add "enableNoTitlebarForWindow" for DPlatformWindowHandle

### DIFF
--- a/src/util/dwindowmanagerhelper.h
+++ b/src/util/dwindowmanagerhelper.h
@@ -34,6 +34,7 @@ class DWindowManagerHelper : public QObject, public DTK_CORE_NAMESPACE::DObject
 
     Q_PROPERTY(bool hasBlurWindow READ hasBlurWindow NOTIFY hasBlurWindowChanged)
     Q_PROPERTY(bool hasComposite READ hasComposite NOTIFY hasCompositeChanged)
+    Q_PROPERTY(bool hasNoTitlebar READ hasNoTitlebar NOTIFY hasNoTitlebarChanged)
 
 public:
     enum MotifFunction {
@@ -79,6 +80,7 @@ public:
 
     bool hasBlurWindow() const;
     bool hasComposite() const;
+    bool hasNoTitlebar() const;
     QString windowManagerNameString() const;
     WMName windowManagerName() const;
 
@@ -90,6 +92,7 @@ Q_SIGNALS:
     void windowManagerChanged();
     void hasBlurWindowChanged();
     void hasCompositeChanged();
+    void hasNoTitlebarChanged();
     void windowListChanged();
     void windowMotifWMHintsChanged(quint32 winId);
 

--- a/src/widgets/dabstractdialog.cpp
+++ b/src/widgets/dabstractdialog.cpp
@@ -61,6 +61,8 @@ void DAbstractDialogPrivate::init()
 //        DPlatformWindowHandle::connectWindowManagerChangedSignal(q, [this] {
 //            bgBlurWidget->setVisible(DPlatformWindowHandle::hasBlurWindow());
 //        });
+    } else {
+        q->setWindowFlags(q->windowFlags() | Qt::FramelessWindowHint);
     }
 
     windowTitle = new QLabel(q);
@@ -69,8 +71,6 @@ void DAbstractDialogPrivate::init()
     q->connect(q,&QWidget::windowTitleChanged, windowTitle,[=](const QString &title){
         windowTitle->setText(title);
     });
-
-    q->setWindowFlags(q->windowFlags() | Qt::FramelessWindowHint  | Qt::WindowCloseButtonHint);
 
     q->setAttribute(Qt::WA_TranslucentBackground);
     q->resize(DIALOG::DEFAULT_WIDTH, DIALOG::DEFAULT_HEIGHT);

--- a/src/widgets/dplatformwindowhandle.h
+++ b/src/widgets/dplatformwindowhandle.h
@@ -67,6 +67,9 @@ public:
     static bool isEnabledDXcb(const QWidget *widget);
     static bool isEnabledDXcb(const QWindow *window);
 
+    static bool setEnableNoTitlebarForWindow(QWindow *window, bool enable);
+    static bool isEnableNoTitlebar(QWindow *window);
+
     struct WMBlurArea {
         qint32 x = 0;
         qint32 y = 0;


### PR DESCRIPTION
Support for custom window decorators using new interfaces
See: https://github.com/linuxdeepin/qt5dxcb-plugin/pull/25

支持调用窗管提供的隐藏标题栏接口来实现个性化定制窗口的功能