### PR TITLE
refactor: use commit count for the package version

### DIFF
--- a/.release.json
+++ b/.release.json
@@ -1,7 +1,7 @@
 {
         "commit": {
                 "quilt": false,
-                "pkgver": "echo $(git tag | sort -V | tail -n1)'+r'$(date '+%%y%%m%%d%%H%%M%%S')'+g'$(git rev-parse --short HEAD);",
+                "pkgver": "echo $(git tag | sort -V | tail -n1)'+r'$(git log $(git describe --abbrev=0 --tags)..HEAD --oneline|wc -l)'+g'$(git rev-parse --short HEAD);",
                 "dist": "experimental"
         },
         "release": {


### PR DESCRIPTION
Version number no longer depends on datetime

使用当前分支最新tag之后的commit数量当做版本号+r之后的值，不再依赖日期和时间