### PR TITLE
fix: don't full blur background of window if the DBlurEffectWidget::m…

### DIFF
--- a/src/widgets/dblureffectwidget.cpp
+++ b/src/widgets/dblureffectwidget.cpp
@@ -56,7 +56,7 @@ bool DBlurEffectWidgetPrivate::isFull() const
 {
     D_QC(DBlurEffectWidget);
 
-    return full || (q->isTopLevel() && !(blurRectXRadius * blurRectYRadius));
+    return full || (q->isTopLevel() && !(blurRectXRadius * blurRectYRadius) && maskPath.isEmpty());
 }
 
 void DBlurEffectWidgetPrivate::addToBlurEffectWidgetHash()


### PR DESCRIPTION
…askPath is non-empty

修复当控件为顶级窗口时，设置DBlurEffectWidget::maskPath属性无效