### PR TITLE
fix: update style after apply dtk stylesheet

### DIFF
--- a/src/widgets/dabstractdialog.cpp
+++ b/src/widgets/dabstractdialog.cpp
@@ -62,10 +62,6 @@ void DAbstractDialogPrivate::init()
 //            bgBlurWidget->setVisible(DPlatformWindowHandle::hasBlurWindow());
 //        });
 
-        // FIXME: The DAbstractDialog QSS won't apply if we don't set the Qt::FramelessWindowHint flag
-        if (!handle->isEnableNoTitlebar(q->windowHandle())) {
-            q->setWindowFlags(q->windowFlags() | Qt::FramelessWindowHint);
-        }
     } else {
         q->setWindowFlags(q->windowFlags() | Qt::FramelessWindowHint);
         q->setBorderColor(QColor(0, 0, 0));

--- a/src/widgets/dthememanager.cpp
+++ b/src/widgets/dthememanager.cpp
@@ -269,6 +269,7 @@ public:
 
         auto dtm = DThemeManager::instance();
         widget->setStyleSheet(widget->styleSheet() + dtm->d_func()->getQssContent(themeurl));
+        widget->style()->polish(widget);
 
         auto reloadTheme = [this, dtm](QWidget * widget, const QString & filename, const QString & themename) {
             const char *baseClassReloadThemeProp = "_dtk_theme_base_calss_reload_theme";


### PR DESCRIPTION
If we don't require an UI update here, then `Qt::FramelessWindowHint` window will not able to apply custom QSS. The one from DTK will be used, the one from user can be set but doesn't works, so we need a polish() call here.

The problem comes after 9a9bf0b24d7c3beb458d64c23d750add3362b0d5 which removed the `Qt::FramelessWindowHint` window flag from DAbstractDialog, which also affacted the DSettingsDialog won't show the close button and option with buttongroup type correctly, and also linuxdeepin/developer-center#1378 since the preview dialog also use DAbstractDialog.

Minimum way to reproduce this issue is, create a `QApplication`(we don't need a `DApplication` to reproduce this issue), create a new class with `DAbstractDialog` as base class, apply a custom QSS on it.

``` cpp
    // sample code:
    DTestDialog d; // DTestDialog derived from DAbstractDialog

    QFile themeFile(":/light/filename.theme");
    themeFile.open(QFile::ReadOnly);
    QString style( themeFile.readAll() );

    d.setStyleSheet( style );
    d.show();
```

And then you'll see all the custom QSS won't work.

Previous commit ( 3128c340bded20d34bea5d3c2fdf8571b1aec3f8 ) is a workaround fix, this fix also doesn't fix the root issue (why window with `Qt::FramelessWindowHint` flag works without any issue) but this fix is much cleaner than the previous one.

Feel free to replace this with a better solution.