### PR TITLE
fix: rpm BuildRequires make

### DIFF
--- a/rpm/dtkwidget.spec
+++ b/rpm/dtkwidget.spec
@@ -39,6 +39,7 @@ BuildRequires:  cups-devel
 
 # libQt5Gui.so.5(Qt_5.10.1_PRIVATE_API)(64bit) needed by dtkwidget-2.0.6.1-1.fc29.x86_64
 BuildRequires:  qt5-qtbase-private-devel
+BuildRequires:  make
 %{?_qt5:Requires: %{_qt5}%{?_isa} = %{_qt5_version}}
 
 %description


### PR DESCRIPTION
Fedora no longer installs make in the default build environment.

Log:
Signed-off-by: Robin Lee <cheeselee@fedoraproject.org>