### PR TITLE
DTK_STATIC_TRANSLATION is set by default.

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -20,7 +20,7 @@ endif
 	dh $@
 
 override_dh_auto_configure:
-	dh_auto_configure -- -DBUILD_PLUGINS=OFF -DBUILD_DOCS=ON -DDTK_VERSION=$(_PACK_VER)
+	dh_auto_configure -- -DBUILD_PLUGINS=OFF -DBUILD_DOCS=ON -DDTK_VERSION=$(_PACK_VER) -DDTK_STATIC_TRANSLATION=YES
 #override_dh_auto_configure:
 #	dh_auto_configure -- LIB_INSTALL_DIR=/usr/lib/$(DEB_HOST_MULTIARCH)
 #override_dh_makeshlibs:


### PR DESCRIPTION
Because the store strictly limits the installation path of third-party applications. Adding this path may simplify third-party application development.