### PR TITLE
fix: wayland DArrowRectangle mouse propagation

### DIFF
--- a/src/widgets/darrowrectangle.cpp
+++ b/src/widgets/darrowrectangle.cpp
@@ -1112,10 +1112,6 @@ void DArrowRectanglePrivate::updateClipPath()
 {
     D_Q(DArrowRectangle);
 
-    if (!m_handle) {
-        return;
-    }
-
     QPainterPath path;
 
     switch (m_arrowDirection) {
@@ -1135,7 +1131,19 @@ void DArrowRectanglePrivate::updateClipPath()
         path = getRightCornerPath();
     }
 
-    m_handle->setClipPath(path);
+    if (m_handle) {
+        m_handle->setClipPath(path);
+    } else {
+        // clipPath without handle
+        QPainterPathStroker stroker;
+        stroker.setCapStyle(Qt::RoundCap);
+        stroker.setJoinStyle(Qt::RoundJoin);
+        stroker.setWidth(2);
+        QPainterPath outPath = stroker.createStroke(path);
+        QPolygon polygon = outPath.united(path).toFillPolygon().toPolygon();
+
+        q->setMask(polygon);
+    }
 }
 
 bool DArrowRectanglePrivate::radiusEnabled()
@@ -1200,12 +1208,12 @@ void DArrowRectanglePrivate::init(DArrowRectangle::FloatMode mode)
             this->updateClipPath();
         }, Qt::QueuedConnection);
     } else {
-        DGraphicsGlowEffect *glowEffect = new DGraphicsGlowEffect;
-        glowEffect->setBlurRadius(q->shadowBlurRadius());
-        glowEffect->setDistance(m_shadowDistance);
-        glowEffect->setXOffset(q->shadowXOffset());
-        glowEffect->setYOffset(q->shadowYOffset());
-        q->setGraphicsEffect(glowEffect);
+//        DGraphicsGlowEffect *glowEffect = new DGraphicsGlowEffect;
+//        glowEffect->setBlurRadius(q->shadowBlurRadius());
+//        glowEffect->setDistance(m_shadowDistance);
+//        glowEffect->setXOffset(q->shadowXOffset());
+//        glowEffect->setYOffset(q->shadowYOffset());
+//        q->setGraphicsEffect(glowEffect);
 
         m_wmHelper = nullptr;
     }

--- a/src/widgets/darrowrectangle.cpp
+++ b/src/widgets/darrowrectangle.cpp
@@ -1208,13 +1208,6 @@ void DArrowRectanglePrivate::init(DArrowRectangle::FloatMode mode)
             this->updateClipPath();
         }, Qt::QueuedConnection);
     } else {
-//        DGraphicsGlowEffect *glowEffect = new DGraphicsGlowEffect;
-//        glowEffect->setBlurRadius(q->shadowBlurRadius());
-//        glowEffect->setDistance(m_shadowDistance);
-//        glowEffect->setXOffset(q->shadowXOffset());
-//        glowEffect->setYOffset(q->shadowYOffset());
-//        q->setGraphicsEffect(glowEffect);
-
         m_wmHelper = nullptr;
     }
 }


### PR DESCRIPTION
wayland 下绘制透明的区域没有鼠标穿透导致无法点击后面的控件。
如果 handle 无效，则使用 qwidget::setmask

Bug: https://pms.uniontech.com/bug-view-99340.html
Influence: wayland-DArrowRectangle-dde-calendar
Change-Id: I0ce66452e443acf88cd3b5b72514ed3bff3a8bd2