### PR TITLE
fix: wayland 下关闭按钮禁用后不能取消禁用状态

### DIFF
--- a/src/widgets/dtitlebar.cpp
+++ b/src/widgets/dtitlebar.cpp
@@ -643,9 +643,7 @@ void DTitlebarPrivate::updateButtonsFunc()
         return;
     }
     if (!qgetenv("WAYLAND_DISPLAY").isEmpty()) {
-        if (disableFlags.testFlag(Qt::WindowCloseButtonHint)) {
-            closeButton->setEnabled(false);
-        }
+        closeButton->setEnabled(!disableFlags.testFlag(Qt::WindowCloseButtonHint));
         return;
     }
 


### PR DESCRIPTION
之前适配了wayland的关闭按钮的禁用功能，未考虑全面

Log: 
Influence: wayland 下所有 dtk 应用的关闭按钮的禁用状态
Bug: https://pms.uniontech.com/bug-view-117469.html