### PR TITLE
fix: 通过控制中心修改字体，全英文文件名称编辑最后一行显示超长

### DIFF
--- a/src/widgets/dtextedit.cpp
+++ b/src/widgets/dtextedit.cpp
@@ -84,7 +84,7 @@ bool DTextEdit::event(QEvent *e)
         return true;
     } else if (e->type() == QEvent::Polish) {
         DStyleHelper dstyle(style());
-        int frame_radius = dstyle.pixelMetric(DStyle::PM_FrameRadius, nullptr, this);
+        int frame_radius = dstyle.pixelMetric(DStyle::PM_FrameRadius, nullptr, this) / 2;
         setViewportMargins(frame_radius, 0, frame_radius, 0);
 
         d->widgetTop->setFixedHeight(frame_radius);


### PR DESCRIPTION
修改DTextEdit的frame_radius为之前的1/2

Log: 修复通过控制中心修改字体，全英文文件名称编辑最后一行显示超长问题
Bug: https://pms.uniontech.com/bug-view-118769.html
Influence: 文本框字体显示