### PR TITLE
chore: DTextEdit crashed when NoTextInteraction was set

### DIFF
--- a/src/widgets/dwindowclosebutton.cpp
+++ b/src/widgets/dwindowclosebutton.cpp
@@ -35,8 +35,11 @@ DWIDGET_BEGIN_NAMESPACE
   \a parent 为创建对象的父控件。
  */
 DWindowCloseButton::DWindowCloseButton(QWidget * parent)
-    : DIconButton(QStyle::SP_TitleBarCloseButton, parent)
+    : DIconButton(parent)
 {
+    //QStyle::SP_TitleBarCloseButton
+    auto iconEngine = new DStyledIconEngine(DDrawUtils::drawTitleBarCloseButton, QStringLiteral("TitleBarCloseButton"));
+    setIcon(QIcon(iconEngine));
     setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Expanding);
     setFlat(true);
 }

--- a/src/widgets/dwindowmaxbutton.cpp
+++ b/src/widgets/dwindowmaxbutton.cpp
@@ -26,11 +26,24 @@ public:
     DWindowMaxButtonPrivate(DWindowMaxButton* qq)
         : DIconButtonPrivate(qq)
     {
-        m_isMaximized = false;
+    }
+
+    void setMaximized(bool isMaximized)
+    {
+        if (isMaximized == m_isMaximized)
+            return;
+
+        m_isMaximized = isMaximized;
+        auto drawFun = !isMaximized ? DDrawUtils::drawTitleBarMaxButton : DDrawUtils::drawTitleBarNormalButton;
+        QString iconName = !isMaximized ? QStringLiteral("TitleBarMaxButton") : QStringLiteral("TitleBarNormalButton");
+
+        q_func()->setIcon(QIcon (new DStyledIconEngine(drawFun, iconName)));
+
+        Q_EMIT q_func()->maximizedChanged(isMaximized);
     }
 
 private:
-    bool m_isMaximized;
+    bool m_isMaximized = true;
     Q_DECLARE_PUBLIC(DWindowMaxButton)
 };
 
@@ -56,7 +69,7 @@ DWindowMaxButton::DWindowMaxButton(QWidget * parent) :
     DIconButton(*new DWindowMaxButtonPrivate(this), parent)
 {
     setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Expanding);
-    setIcon(QStyle::SP_TitleBarMaxButton);
+    setMaximized(false);
     setFlat(true);
 }
 
@@ -93,18 +106,7 @@ void DWindowMaxButton::setMaximized(bool isMaximized)
 {
     D_D(DWindowMaxButton);
 
-    if (d->m_isMaximized == isMaximized)
-        return;
-
-    d->m_isMaximized = isMaximized;
-
-    if (isMaximized) {
-        setIcon(QStyle::SP_TitleBarNormalButton);
-    } else {
-        setIcon(QStyle::SP_TitleBarMaxButton);
-    }
-
-    Q_EMIT maximizedChanged(isMaximized);
+    d->setMaximized(isMaximized);
 }
 
 void DWindowMaxButton::initStyleOption(DStyleOptionButton *option) const

--- a/src/widgets/dwindowminbutton.cpp
+++ b/src/widgets/dwindowminbutton.cpp
@@ -40,6 +40,9 @@ DWIDGET_BEGIN_NAMESPACE
 DWindowMinButton::DWindowMinButton(QWidget * parent)
     : DIconButton(QStyle::SP_TitleBarMinButton, parent)
 {
+    //QStyle::SP_TitleBarMinButton
+    auto iconEngine = new DStyledIconEngine(DDrawUtils::drawTitleBarMinButton, QStringLiteral("TitleBarMinButton"));
+    setIcon(QIcon(iconEngine));
     setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Expanding);
     setFlat(true);
 }

--- a/src/widgets/dwindowoptionbutton.cpp
+++ b/src/widgets/dwindowoptionbutton.cpp
@@ -36,8 +36,11 @@ DWIDGET_BEGIN_NAMESPACE
   \a parent 为创建对象的父控件。
  */
 DWindowOptionButton::DWindowOptionButton(QWidget * parent)
-    : DIconButton(QStyle::SP_TitleBarMenuButton, parent)
+    : DIconButton(parent)
 {
+    //QStyle::SP_TitleBarMenuButton
+    auto iconEngine = new DStyledIconEngine(DDrawUtils::drawTitleBarMenuButton, QStringLiteral("TitleBarMenuButton"));
+    setIcon(QIcon(iconEngine));
     setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Expanding);
     setFlat(true);
 }

--- a/src/widgets/dwindowquitfullbutton.cpp
+++ b/src/widgets/dwindowquitfullbutton.cpp
@@ -26,8 +26,11 @@
 DWIDGET_BEGIN_NAMESPACE
 
 DWindowQuitFullButton::DWindowQuitFullButton(QWidget * parent)
-    : DIconButton(DStyle::SP_TitleQuitFullButton ,parent)
+    : DIconButton(parent)
 {
+    //DStyle::SP_TitleQuitFullButton
+    auto iconEngine = new DStyledIconEngine(DDrawUtils::drawTitleQuitFullButton, QStringLiteral("TitleQuitFullButton"));
+    setIcon(QIcon(iconEngine));
     setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Expanding);
     setFlat(true);
 }


### PR DESCRIPTION
when NoTextInteraction was set,  createStandardContextMenu() return nullptr.

Log: DTextEdit崩溃问题修复
Influence: DTextEdit-menu-crash
Change-Id: I632d90555809bcb844fab7e1fbbccf3e816e8b3a