### PR TITLE
chore: DTextEdit crashed when NoTextInteraction was set

### DIFF
--- a/src/widgets/dtextedit.cpp
+++ b/src/widgets/dtextedit.cpp
@@ -171,6 +171,9 @@ void DTextEdit::contextMenuEvent(QContextMenuEvent *e)
     }
 
     QMenu *menu = createStandardContextMenu();
+    if (!menu)
+        return QTextEdit::contextMenuEvent(e);
+
     menu->addSeparator();
 
     connect(menu, &QMenu::triggered, this, [this](QAction *pAction) {


### PR DESCRIPTION
when NoTextInteraction was set, createStandardContextMenu() return nullptr.

Log: DTextEdit崩溃问题修复
Influence: DTextEdit-menu-crash
Change-Id: I632d90555809bcb844fab7e1fbbccf3e816e8b3a