### PR TITLE
fix: wayland下tooltips没有跟随输入框

### DIFF
--- a/src/widgets/dalertcontrol.cpp
+++ b/src/widgets/dalertcontrol.cpp
@@ -294,7 +294,7 @@ bool DAlertControl::eventFilter(QObject *watched, QEvent *event)
     }
 
     if (d->follower && watched == d->follower->topLevelWidget()) {
-        if (event->type() == QEvent::HoverMove)
+        if (event->type() == QEvent::HoverMove || event->type() == QEvent::UpdateRequest)
             d->updateTooltipPos();
 
         if (d->timer.isActive())


### PR DESCRIPTION
增加对UpdateRequest事件类型的判断

Log: 修复wayland下tooltips未跟随输入框问题
Bug: https://pms.uniontech.com/bug-view-124413.html
Influence: 输入框警告信息