### PR TITLE
chore: dtkwidget csd without dxcb

### DIFF
--- a/src/util/dwidgetutil.cpp
+++ b/src/util/dwidgetutil.cpp
@@ -23,6 +23,7 @@
 #include <QTextLayout>
 #include <QApplication>
 #include <QDesktopWidget>
+#include <qpa/qplatformwindow.h>
 
 QT_BEGIN_NAMESPACE
 //extern Q_WIDGETS_EXPORT void qt_blurImage(QImage &blurImage, qreal radius, bool quality, int transposed = 0);
@@ -103,6 +104,19 @@ QIcon getCircleIcon(const QIcon &icon, int diameter)
 {
     QPixmap pixmap = icon.pixmap(QSize(diameter, diameter));
     return getCircleIcon(pixmap, diameter);
+}
+
+bool startMoveWindow(QWindow *window, QPoint pos)
+{
+    if (Q_UNLIKELY(!window || !window->isVisible() || !window->handle()))
+        return false;
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
+    return window->handle()->startSystemMove(pos);
+#else
+    Q_UNUSED(pos);
+    return window->handle()->startSystemMove();
+#endif
 }
 
 DWIDGET_END_NAMESPACE

--- a/src/util/dwidgetutil.h
+++ b/src/util/dwidgetutil.h
@@ -44,6 +44,10 @@ QIcon getCircleIcon(const QIcon &icon, int diameter = 36);
 
 void moveToCenter(QWidget *w);
 
+// 使用平台接口移动窗口， qt 5.15及以后不需要传入pos，5.15之前需要传入localpos
+bool startMoveWindow(QWindow *window, QPoint pos = QPoint());
+
+
 DWIDGET_END_NAMESPACE
 
 #endif // DUTILITY_H

--- a/src/widgets/dabstractdialog.cpp
+++ b/src/widgets/dabstractdialog.cpp
@@ -25,6 +25,7 @@
 #include <QLabel>
 #include <QDebug>
 #include <QComboBox>
+#include <qpa/qplatformwindow.h>
 
 #include "danchors.h"
 #include "dialog_constants.h"
@@ -36,6 +37,7 @@
 
 #include <DGuiApplicationHelper>
 #include <DWindowManagerHelper>
+#include <DWidgetUtil>
 
 DWIDGET_BEGIN_NAMESPACE
 
@@ -74,8 +76,9 @@ void DAbstractDialogPrivate::init(bool blurIfPossible)
         q->setAttribute(Qt::WA_TranslucentBackground, blurIfPossible);
     } else if (qApp->platformName() == "dwayland" || qApp->property("_d_isDwayland").toBool()) {
         handle = new DPlatformWindowHandle(q, q);
-        // fix wayland no titlebar
-        //q->setWindowFlags(q->windowFlags() | Qt::FramelessWindowHint);
+    } else {
+        // csd
+        q->setWindowFlags(q->windowFlags() | Qt::FramelessWindowHint);
     }
 
     q->resize(DIALOG::DEFAULT_WIDTH, DIALOG::DEFAULT_HEIGHT);
@@ -370,7 +373,8 @@ void DAbstractDialog::mouseMoveEvent(QMouseEvent *event)
     }
 
     if (d->mousePressed) {
-        move(event->globalPos() - d->dragPosition);
+        //move(event->globalPos() - d->dragPosition);
+        startMoveWindow(windowHandle(), event->pos());
         d->mouseMoved = true;
     }
 

--- a/src/widgets/ddialog.cpp
+++ b/src/widgets/ddialog.cpp
@@ -122,7 +122,7 @@ void DDialogPrivate::init()
         qApp->acclimatizeVirtualKeyboard(contentWidget);
     }
 
-    titleBar = new DTitlebar();
+    titleBar = new DTitlebar(q);
     titleBar->setAccessibleName("DDialogTitleBar");
     titleBar->setIcon(icon); //设置标题icon
     titleBar->setMenuVisible(false);

--- a/src/widgets/dmainwindow.cpp
+++ b/src/widgets/dmainwindow.cpp
@@ -53,7 +53,8 @@ DMainWindowPrivate::DMainWindowPrivate(DMainWindow *qq)
 #ifdef Q_OS_MAC
         OSX::HideWindowTitlebar(qq->winId());
 #else
-        titlebar->setEmbedMode(true);
+     //   titlebar->setEmbedMode(true);
+     qq->setWindowFlag(Qt::FramelessWindowHint);
 #endif
     }
 

--- a/src/widgets/dsettingsdialog.cpp
+++ b/src/widgets/dsettingsdialog.cpp
@@ -85,7 +85,8 @@ DSettingsDialog::DSettingsDialog(QWidget *parent) :
     rightFrame->setAccessibleName("DSettingDialogRightFrame");
 
     QVBoxLayout *rightlayout = new QVBoxLayout(rightFrame);
-    d->frameBar = new DTitlebar;
+    d->frameBar = new DTitlebar(this);
+    setWindowFlag(Qt::FramelessWindowHint);
     d->frameBar->setMenuVisible(false);
     d->frameBar->setTitle(QString());
     d->frameBar->setAccessibleName("DSettingTitleBar");


### PR DESCRIPTION
1. setWindowFlag Qt::FramelessWindowHint
2. call startSystemMove when mouse move with left button pressed
3. always show dtitlebar buttons

Log: 
Incluence: notitlebar without dxcb plugin
Change-Id: I57caa33f56306540fd62e8e7bf13d59a7ad46cee