### PR TITLE
chore: wayland无标题栏兼容旧版kwin

### DIFF
--- a/src/widgets/dabstractdialog.cpp
+++ b/src/widgets/dabstractdialog.cpp
@@ -51,6 +51,12 @@ void DAbstractDialogPrivate::init(bool blurIfPossible)
     // TODO: 这里对dialog特殊处理，dialog不需要设置固定的位置，否则里面的坐标会发生偏移导致点击偏移
     // 但是这不是问题的根本原因，还需要进一步分析。该属性在插件中做了特殊处理
     q->QDialog::setProperty("DAbstractDialog", true);
+    auto noTitlebarEnabled = []{
+        QFunctionPointer enableNoTitlebar = qApp->platformFunction("_d_isEnableNoTitlebar");
+        bool enabled = qApp->platformName() == "dwayland" || qApp->property("_d_isDwayland").toBool();
+        return enabled && enableNoTitlebar != nullptr;
+    };
+
     if (qApp->isDXcbPlatform()) {
         handle = new DPlatformWindowHandle(q, q);
 
@@ -72,7 +78,7 @@ void DAbstractDialogPrivate::init(bool blurIfPossible)
 
         bgBlurWidget->setBlurEnabled(blurIfPossible);
         q->setAttribute(Qt::WA_TranslucentBackground, blurIfPossible);
-    } else if (qApp->platformName() == "dwayland" || qApp->property("_d_isDwayland").toBool()) {
+    } else if (noTitlebarEnabled()) {
         handle = new DPlatformWindowHandle(q, q);
         // fix wayland no titlebar
         //q->setWindowFlags(q->windowFlags() | Qt::FramelessWindowHint);

--- a/src/widgets/dmainwindow.cpp
+++ b/src/widgets/dmainwindow.cpp
@@ -45,7 +45,12 @@ DMainWindowPrivate::DMainWindowPrivate(DMainWindow *qq)
 {
     titlebar = new DTitlebar(qq);
     titlebar->setAccessibleName("DMainWindowTitlebar");
-    if (DApplication::isDXcbPlatform() || (qApp->platformName() == "dwayland" || qApp->property("_d_isDwayland").toBool())) {
+    auto noTitlebarEnabled = []{
+        QFunctionPointer enableNoTitlebar = qApp->platformFunction("_d_isEnableNoTitlebar");
+        bool enabled = qApp->platformName() == "dwayland" || qApp->property("_d_isDwayland").toBool();
+        return enabled && enableNoTitlebar != nullptr;
+    };
+    if (DApplication::isDXcbPlatform() || noTitlebarEnabled()) {
         handle = new DPlatformWindowHandle(qq, qq);
         qq->setMenuWidget(titlebar);
     } else {

--- a/src/widgets/dtitlebar.cpp
+++ b/src/widgets/dtitlebar.cpp
@@ -517,8 +517,13 @@ void DTitlebarPrivate::init()
     // 另外，让标题栏接收焦点，还是为了避免一个focus控件隐藏时，会把焦点转移给标题栏上的按钮控件
     q->setFocusPolicy(Qt::StrongFocus);
 
+    auto noTitlebarEnabled = []{
+        QFunctionPointer enableNoTitlebar = qApp->platformFunction("_d_isEnableNoTitlebar");
+        bool enabled = qApp->platformName() == "dwayland" || qApp->property("_d_isDwayland").toBool();
+        return enabled && enableNoTitlebar != nullptr;
+    };
     // fix wayland 下显示了两个应用图标，系统标题栏 和 dtk标题栏 均显示应用图标
-    q->setEmbedMode(!(DApplication::isDXcbPlatform()|| (qApp->platformName() == "dwayland" || qApp->property("_d_isDwayland").toBool())));
+    q->setEmbedMode(!(DApplication::isDXcbPlatform()|| noTitlebarEnabled()));
 }
 
 QWidget *DTitlebarPrivate::targetWindow()


### PR DESCRIPTION
适配了无标题栏后，旧版kwin上的无标题栏会显示两列按钮
不支持无标题栏时dtk的标题栏不应该显示菜单

Log:
Influence: