### PR TITLE
fix: wayland环境网络链接对话框点击无效

### DIFF
--- a/src/widgets/darrowrectangle.cpp
+++ b/src/widgets/darrowrectangle.cpp
@@ -1138,10 +1138,18 @@ void DArrowRectanglePrivate::updateClipPath()
         QPainterPathStroker stroker;
         stroker.setCapStyle(Qt::RoundCap);
         stroker.setJoinStyle(Qt::RoundJoin);
-        stroker.setWidth(2);
+        // stroker.setWidth(2);
         QPainterPath outPath = stroker.createStroke(path);
+
+        if (q->windowHandle() && q->isTopLevel()) {
+            D_Q(DArrowRectangle);
+            qreal device_pixel_ratio = q->windowHandle()->screen()->devicePixelRatio();
+            outPath = outPath * device_pixel_ratio;
+        }
+
         QPolygon polygon = outPath.united(path).toFillPolygon().toPolygon();
 
+        q->clearMask();
         q->setMask(polygon);
     }
 }

--- a/src/widgets/darrowrectangle.h
+++ b/src/widgets/darrowrectangle.h
@@ -131,4 +131,22 @@ protected:
 
 DWIDGET_END_NAMESPACE
 
+QT_BEGIN_NAMESPACE
+inline QPainterPath operator *(const QPainterPath &path, qreal scale)
+{
+    if (qFuzzyCompare(1.0, scale))
+        return path;
+
+    QPainterPath new_path = path;
+
+    for (int i = 0; i < path.elementCount(); ++i) {
+        const QPainterPath::Element &e = path.elementAt(i);
+
+        new_path.setElementPositionAt(i, qRound(e.x * scale), qRound(e.y * scale));
+    }
+
+    return new_path;
+}
+QT_END_NAMESPACE
+
 #endif // DARROWRECTANGLE_H


### PR DESCRIPTION
网络连接对话框在设置了屏幕缩放的情况下会透过鼠标事件
导致点击不上按钮，原因是setMask之前要清空旧值

Log:
Bug: https://pms.uniontech.com/bug-view-130007.html
Influence: DarrowRectangle的点击操作