### PR TITLE
fix: wayland环境网络链接对话框点击无效

### DIFF
--- a/src/widgets/darrowrectangle.cpp
+++ b/src/widgets/darrowrectangle.cpp
@@ -1142,6 +1142,7 @@ void DArrowRectanglePrivate::updateClipPath()
         QPainterPath outPath = stroker.createStroke(path);
         QPolygon polygon = outPath.united(path).toFillPolygon().toPolygon();
 
+        q->clearMask();
         q->setMask(polygon);
     }
 }


### PR DESCRIPTION
网络连接对话框在设置了屏幕缩放的情况下会透过鼠标事件
导致点击不上按钮，原因是setMask之前要清空旧值

Log:
Bug: https://pms.uniontech.com/bug-view-130007.html
Influence: DarrowRectangle的点击操作