### PR TITLE
fix: 打印预览titlebar不跟随主题变化

### DIFF
--- a/src/widgets/dprintpreviewdialog.cpp
+++ b/src/widgets/dprintpreviewdialog.cpp
@@ -1151,7 +1151,14 @@ void DPrintPreviewDialogPrivate::initconnections()
     QObject::connect(marginRightSpin, SIGNAL(editingFinished()), q, SLOT(_q_marginEditFinished()));
     QObject::connect(marginLeftSpin, SIGNAL(editingFinished()), q, SLOT(_q_marginEditFinished()));
     QObject::connect(marginBottomSpin, SIGNAL(editingFinished()), q, SLOT(_q_marginEditFinished()));
-    QObject::connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::themeTypeChanged, q, [this](DGuiApplicationHelper::ColorType themeType) { this->themeTypeChange(themeType); });
+    QObject::connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::themeTypeChanged,
+                     q, [this, q](DGuiApplicationHelper::ColorType themeType) {
+        DTitlebar *titlebar = q->findChild<DTitlebar *>();
+        DPalette pa = DPaletteHelper::instance()->palette(titlebar);
+        pa.setBrush(DPalette::Background, pa.base());
+        DPaletteHelper::instance()->setPalette(titlebar, pa);
+        this->themeTypeChange(themeType);
+    });
     QObject::connect(marginTopSpin->lineEdit(), SIGNAL(textEdited(const QString &)), q, SLOT(_q_spinboxValueEmptyChecked(const QString &)));
     QObject::connect(marginRightSpin->lineEdit(), SIGNAL(textEdited(const QString &)), q, SLOT(_q_spinboxValueEmptyChecked(const QString &)));
     QObject::connect(marginLeftSpin->lineEdit(), SIGNAL(textEdited(const QString &)), q, SLOT(_q_spinboxValueEmptyChecked(const QString &)));


### PR DESCRIPTION
主动设置了titlebar的palette后，要在主题变化的时候再次主动更新

Log:
Bug: https://pms.uniontech.com/bug-view-129709.html
Influence: 标题栏随主题色变化