### PR TITLE
fix: 设置界面backgrounGroup背景色问题

### DIFF
--- a/src/widgets/private/settings/content.cpp
+++ b/src/widgets/private/settings/content.cpp
@@ -280,6 +280,7 @@ void Content::updateSettings(const QByteArray &translateContext, QPointer<DTK_CO
             bgGroup->setItemSpacing(1);
             bgGroup->setItemMargins(QMargins(0, 0, 0, 0));
             bgGroup->setBackgroundRole(QPalette::Window);
+            bgGroup->setUseWidgetBackground(false);
             d->contentLayout->addWidget(bgGroup);
 
             for (auto option : subgroup->childOptions()) {


### PR DESCRIPTION
设置backgroundGroup的useWidgetBackground为false

Log: 修复设置界面backgroundGroup背景色问题
Bug: https://pms.uniontech.com/bug-view-138331.html
Influence: 设置界面背景色