### PR TITLE
fix: 非激活listview内的字体样式未置灰

### DIFF
--- a/src/widgets/dstyleditemdelegate.cpp
+++ b/src/widgets/dstyleditemdelegate.cpp
@@ -785,6 +785,10 @@ void DStyledItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &o
     // 图标的绘制用也可能会使用这些颜色
     QPalette::ColorGroup cg = opt.state & QStyle::State_Enabled
                           ? QPalette::Normal : QPalette::Disabled;
+
+    if (cg == QPalette::Normal && !(opt.state & QStyle::State_Active))
+        cg = QPalette::Inactive;
+
     if (opt.state & QStyle::State_Selected) {
         painter->setPen(opt.palette.color(cg, QPalette::HighlightedText));
     } else {
@@ -1113,6 +1117,11 @@ void DStyledItemDelegate::initStyleOption(QStyleOptionViewItem *option, const QM
             option->rect.adjust(0, 0, 0 - d->itemSpacing, 0);
         } else {
             option->rect.adjust(0, 0, 0, 0 - d->itemSpacing);
+        }
+        if (lv->window() && lv->window()->isActiveWindow()) {
+            option->state |= QStyle::State_Active;
+        } else {
+            option->state &= (~QStyle::State_Active);
         }
     }
 


### PR DESCRIPTION
1.判断listview窗体是否激活，设置其状态。
2.设置非激活状态下的colorgroup为QPalette::Inactive。

Log: 修复非激活listview内字体样式未置灰问题
Bug: https://pms.uniontech.com/bug-view-138395.html
Influence: listview非激活状态UI