### PR TITLE
fix: 双击文件标记框后会随机变色

### DIFF
--- a/src/widgets/dcrumbedit.cpp
+++ b/src/widgets/dcrumbedit.cpp
@@ -318,6 +318,8 @@ public:
         DCrumbTextFormat format = q->makeTextFormat();
 
         format.setText(tag_text);
+        if (currentText == tag_text)
+            format.setBackground(currentBrush);
         cursor.insertText(QString(QChar::ObjectReplacementCharacter), format);
     }
 
@@ -358,6 +360,8 @@ public:
             return false;
 
         DCrumbTextFormat format(cursor.charFormat());
+        currentText = format.text();
+        currentBrush = format.background();
 
         if (format.text().isEmpty())
             return false;
@@ -514,6 +518,8 @@ public:
     QMap<QString, DCrumbTextFormat> formats;
 
     bool dualClickMakeCrumb = false;
+    QString currentText;
+    QBrush currentBrush;
 
 public:
     QWidget* widgetTop;


### PR DESCRIPTION
双击时保存当前文本内容和当前背景色。
如果文本没有变化，则仍然使用当前背景色。

Log: 修复双击文件标记框后会随机变色问题
Bug: https://pms.uniontech.com/bug-view-139561.html
Influence: 标记框
Change-Id: Ic0315f06bb2ee55da94e8cf9e1bdfd8a649e7922