### PR TITLE
fix: 锁屏界面网络面板显示异常，底色有重叠黑影

### DIFF
--- a/src/widgets/darrowrectangle.cpp
+++ b/src/widgets/darrowrectangle.cpp
@@ -1144,6 +1144,14 @@ void DArrowRectanglePrivate::updateClipPath()
 
         q->clearMask();
         q->setMask(polygon);
+
+        if (QWidget *widget = q->window()) {
+            if (QWindow *w = widget->windowHandle()) {
+                QList<QPainterPath> painterPaths;
+                painterPaths << outPath;
+                w->setProperty("_d_windowBlurPaths", QVariant::fromValue(painterPaths));
+            }
+        }
     }
 }
 


### PR DESCRIPTION
darrowrectangle在updateClipPath时设置属性clipPath，
并且传递参数polygon

Log: 修复锁屏界面网络面板显示异常，底色有重叠黑影问题
Bug: https://pms.uniontech.com/bug-view-124427.html
Influence: wayland下darrowrectangle的UI
Change-Id: Ie398c651c743dae514ce86ee29e88c7de1c9645b