### PR TITLE
fix: 时区页面为透明状态，没有模糊效果

### DIFF
--- a/src/widgets/dblureffectwidget.cpp
+++ b/src/widgets/dblureffectwidget.cpp
@@ -43,6 +43,8 @@
 
 #undef private
 
+#include "dapplication.h"
+
 #define MASK_COLOR_ALPHA_DEFAULT 204
 
 QT_BEGIN_NAMESPACE
@@ -186,6 +188,17 @@ bool DBlurEffectWidgetPrivate::updateWindowBlurArea(QWidget *topLevelWidget)
     }
 
     QList<const DBlurEffectWidget *> blurEffectWidgetList = blurEffectWidgetHash.values(topLevelWidget);
+
+    if (!DApplication::isDXcbPlatform()) {
+        Q_FOREACH (const DBlurEffectWidget *w, blurEffectWidgetList) {
+            if (QWidget *widget = w->window()) {
+                if (QWindow *window = widget->windowHandle()) {
+                    window->setProperty("_d_clipPath", QPolygon(topLevelWidget->rect()));
+                }
+            }
+        }
+        return true;
+    }
 
     bool isExistMaskPath = false;
 


### PR DESCRIPTION
wayland插件加入blur模块后，
通过设置_d_clipPath属性来设置模糊区域。

Log: 修复时区页面没有模糊的问题
Bug: https://pms.uniontech.com/bug-view-126387.html
Influence: 时区页面
Change-Id: I33a5777b5c1a24632101f92da3316bd8cce26adb