### PR TITLE
fix: 设置导航栏一级菜单内容有遮挡

### DIFF
--- a/src/widgets/private/settings/navigationdelegate.cpp
+++ b/src/widgets/private/settings/navigationdelegate.cpp
@@ -51,7 +51,7 @@ void NavigationDelegate::paint(QPainter *painter, const QStyleOptionViewItem &op
         painter->setPen(pen);
         painter->setFont(DFontSizeManager::instance()->get(DFontSizeManager::T4, QFont::Medium, opt.font));
         QRect rect = opt.rect.marginsRemoved(QMargins(10, 0, 10, 0));
-        auto text = opt.fontMetrics.elidedText(index.data().toString(), Qt::ElideRight, rect.width());
+        auto text = painter->fontMetrics().elidedText(index.data().toString(), Qt::ElideRight, rect.width());
         painter->drawText(rect, Qt::AlignLeft | Qt::AlignVCenter, text);
         break;
     }


### PR DESCRIPTION
一级菜单QPainter设置了字体，就用painter的
字体设置省略样式。

Log: 修复设置导航栏一级菜单内容遮挡问题
Bug: https://pms.uniontech.com/bug-view-145915.html
Influence: 设置导航栏
Change-Id: I364d06e313750e80a03aa4ecc7630975f7d34466