### PR TITLE
fix: change pagesize name to readable name

### DIFF
--- a/src/widgets/dprintpreviewdialog.cpp
+++ b/src/widgets/dprintpreviewdialog.cpp
@@ -1288,7 +1288,7 @@ void DPrintPreviewDialogPrivate::judgeSupportedAttributes(const QString &lastPap
     QStringList pageSizeList;
     int index = -1;
     for (int i = 0; i < updateinfo.supportedPageSizes().size(); i++) {
-        pageSizeList.append(updateinfo.supportedPageSizes().at(i).key());
+        pageSizeList.append(updateinfo.supportedPageSizes().at(i).name());
         if (index == -1 && updateinfo.supportedPageSizes().at(i).id() == QPageSize::PageSizeId::A4) {
             index = i;
         }


### PR DESCRIPTION
use QPageSize::name() instead of QPageSize::key()
a localized human-readable name for the page size.

Log:
Influence: printpreview pagesize
Change-Id: I897ef3cc35668a87aa744dbe54f3ae3849bc2206