### PR TITLE
fix: crashed when DListView drag item with Action

### DIFF
--- a/examples/dwidget-examples/collections/listviewexample.cpp
+++ b/examples/dwidget-examples/collections/listviewexample.cpp
@@ -126,6 +126,7 @@ DListViewExample::DListViewExample(QWidget *parent)
     QVBoxLayout *listviewPicLayout = new QVBoxLayout(listviewPicWidget);
     DListView *fingerPrintLV = new DListView(listViewWidget);
     DListView *browserLV = new DListView(listViewWidget);
+    browserLV->setDragDropMode(QListView::InternalMove);
     DListView *screenLV = new DListView(listViewWidget);
     QStandardItemModel *fingerPrintModel = new QStandardItemModel(fingerPrintLV);
     QStandardItemModel *browserModel = new QStandardItemModel(browserLV);
@@ -151,12 +152,21 @@ DListViewExample::DListViewExample(QWidget *parent)
 
     DStandardItem *browserItem1 = new DStandardItem(QIcon("://images/example/DListViewBrowser_1.svg"), "谷歌浏览器");
 
+    browserModel->setItemPrototype(new DStandardItem());
     // 设置其他style时，转换指针为空
     if (DStyle *ds = qobject_cast<DStyle *>(style())) {
         auto action = new DViewItemAction(Qt::AlignVCenter, QSize(), QSize(), true);
         action->setIcon(ds->standardIcon(DStyle::SP_IndicatorChecked));
         action->setParent(this);
         browserItem1->setActionList(Qt::Edge::RightEdge, {action});
+        connect(action, &DViewItemAction::triggered, this, [action, browserModel]() {
+            for (int i = 0; i < browserModel->rowCount(); i++) {
+                auto item =  dynamic_cast<DStandardItem *>(browserModel->item(i));
+                Q_ASSERT(item);
+                if (item->actionList(Qt::RightEdge).contains(action))
+                    qDebug() << "clicked the row" << i;
+            }
+        });
     }
 
     DStandardItem *browserItem2 = new DStandardItem(QIcon("://images/example/DListViewBrowser_2.svg"), "火狐浏览器");
@@ -214,6 +224,13 @@ DListViewExample::DListViewExample(QWidget *parent)
     screenModel->appendRow(screenItem2);
     screenModel->appendRow(screenItem3);
     screenModel->appendRow(screenItem4);
+
+    for (int i = 0 ; i < browserModel->rowCount(); i++)
+    {
+        auto item = browserModel->item(i);
+        item->setDragEnabled(true);
+        item->setDropEnabled(false);
+    }
 
     listViewWLayout->setContentsMargins(85, 0, 85, 0);
     listViewWLayout->setSpacing(60);

--- a/src/widgets/dstyleditemdelegate.h
+++ b/src/widgets/dstyleditemdelegate.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 ~ 2019 Deepin Technology Co., Ltd.
+ * Copyright (C) 2017 ~ 2022 Deepin Technology Co., Ltd.
  *
  * Author:     zccrs <zccrs@live.com>
  *
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 #ifndef DSTYLEDITEMDELEGATE_H
 #define DSTYLEDITEMDELEGATE_H
@@ -135,6 +135,8 @@ public:
 
     void setFontSize(DFontSizeManager::SizeType size);
     QFont font() const;
+
+    virtual QStandardItem *clone() const override;
 };
 
 DWIDGET_END_NAMESPACE

--- a/tests/testcases/widgets/ut_dstyleditemdelegate.cpp
+++ b/tests/testcases/widgets/ut_dstyleditemdelegate.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright (C) 2021 ~ 2021 Uniontech Software Technology Co.,Ltd.
+* Copyright (C) 2021 ~ 2022 Uniontech Software Technology Co.,Ltd.
 *
 * Author:     Ye ShanShan <yeshanshan@uniontech.com>
 *
@@ -16,11 +16,12 @@
 * GNU General Public License for more details.
 *
 * You should have received a copy of the GNU Lesser General Public License
-* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+* along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 #include <gtest/gtest.h>
 #include <QListView>
+#include <QPointer>
 
 #include "dstyleditemdelegate.h"
 DWIDGET_USE_NAMESPACE
@@ -207,3 +208,53 @@ TEST_F(ut_DViewItemAction, setWidget)
     ASSERT_EQ(target->widget(), widget);
     widget->deleteLater();
 };
+
+TEST_F(ut_DViewItemAction, actionDestoryByDStandItem)
+{
+    QStandardItemModel* model = new QStandardItemModel();
+    QPointer<DViewItemAction> actionPointer(new DViewItemAction());
+    ASSERT_TRUE(actionPointer);
+
+    DStandardItem *item = new DStandardItem();
+    item->setActionList(Qt::RightEdge, {actionPointer});
+    model->appendRow(item);
+
+    QPointer<DViewItemAction> actionPointer2(new DViewItemAction());
+    item->setActionList(Qt::RightEdge, {actionPointer2});
+    ASSERT_FALSE(actionPointer);
+
+    // release now avoid DStandardItem is clear in next event loop.
+    delete model;
+
+    ASSERT_FALSE(actionPointer2);
+}
+
+TEST_F(ut_DViewItemAction, actionDestoryByDStandItemWithClone)
+{
+    DStandardItem *item = new DStandardItem();
+    QPointer<DViewItemAction> actionPointer(new DViewItemAction());
+    item->setActionList(Qt::RightEdge, {actionPointer});
+
+    DStandardItem *item2 = dynamic_cast<DStandardItem *>(item->clone());
+    delete item;
+    ASSERT_TRUE(actionPointer);
+    delete item2;
+    ASSERT_FALSE(actionPointer);
+}
+
+TEST_F(ut_DViewItemAction, accessActionByActionList)
+{
+    QStandardItemModel* model = new QStandardItemModel();
+    DViewItemAction *action = new DViewItemAction();
+
+    DStandardItem *item = new DStandardItem();
+    item->setActionList(Qt::RightEdge, {action});
+    model->appendRow(item);
+
+    auto itemModel = dynamic_cast<DStandardItem *>(model->item(0));
+    ASSERT_TRUE(itemModel);
+
+    ASSERT_TRUE(itemModel->actionList(Qt::RightEdge).contains(action));
+
+    model->deleteLater();
+}


### PR DESCRIPTION
  DStandardItem's `setActionList` can't be used with drag because of
Type doesn't support metatype's save and load.
  and DStandardItem doesn't release it's Action when destruction,
we use sharedpointer to manager action's life.
  Add clone override function to support that action can be access
after draged, and it need to setItemPrototype by model.

Log: 含有Action项的DListView拖动时程序崩溃
Influence: none
Change-Id: Idc489b94f4cf95850fe00a9ac8231fed80913a79