### PR TITLE
fix: 双击标记框内标记后面追加文字

### DIFF
--- a/src/widgets/dcrumbedit.cpp
+++ b/src/widgets/dcrumbedit.cpp
@@ -366,6 +366,9 @@ public:
         if (format.text().isEmpty())
             return false;
 
+        if (cursor.atEnd() && mousePos.x() > q->cursorRect().right())
+            return false;
+
         makeCrumb();
 
         if (mousePos.x() < q->cursorRect().left())


### PR DESCRIPTION
当光标在内容末尾且鼠标双击位置在光标右边时，
编辑返回false，不再编辑追加文字。

Log: 修复双击标记框内标记后面追加文字问题
Bug: https://pms.uniontech.com/bug-view-139561.html
Influence: 标记框
Change-Id: Ia582ebf7f40b8180352bfdfec09ac5f615047212