### PR TITLE
fix: 调用语音助手服务不响应导致右键菜单卡死

### DIFF
--- a/src/widgets/dtextedit.cpp
+++ b/src/widgets/dtextedit.cpp
@@ -135,6 +135,16 @@ void DTextEdit::keyPressEvent(QKeyEvent *event)
 
 void DTextEdit::contextMenuEvent(QContextMenuEvent *e)
 {
+    auto msg = QDBusMessage::createMethodCall("com.iflytek.aiassistant", "/",
+                                   "org.freedesktop.DBus.Peer", "Ping");
+    // 用之前 Ping 一下, 300ms 内没回复就认定是服务出问题，不再添加助手菜单项
+    auto pingReply = QDBusConnection::sessionBus().call(msg, QDBus::BlockWithGui, 300);
+    auto errorType = QDBusConnection::sessionBus().lastError().type();
+    if (errorType == QDBusError::Timeout || errorType == QDBusError::NoReply) {
+        qWarning() << pingReply << "\nwill not add aiassistant actions!";
+        return QTextEdit::contextMenuEvent(e);
+    }
+
     QDBusInterface testSpeech("com.iflytek.aiassistant",
                                "/aiassistant/tts",
                                "com.iflytek.aiassistant.tts",


### PR DESCRIPTION
语音助手在某些情况下会不响应，这是直接构造 QDBusInterface
会卡死，加一个 Ping 的操作，如果 300ms 内未响应则不添加
相关菜单

Bug: https://pms.uniontech.com/bug-view-151279.html
Log:
Influence: edit context menu
Change-Id: Id8e3f6f53a011b70fa12d95ff1cc3a6fec94021b