### PR TITLE
feat: Enable DListView and DViewItemAction to support DciIcon

### DIFF
--- a/src/widgets/dstyleditemdelegate.h
+++ b/src/widgets/dstyleditemdelegate.h
@@ -31,6 +31,10 @@
 #include <QStandardItem>
 #include <QAbstractItemView>
 
+DGUI_BEGIN_NAMESPACE
+class DDciIcon;
+DGUI_END_NAMESPACE
+
 DWIDGET_BEGIN_NAMESPACE
 
 class DViewItemActionPrivate;
@@ -64,6 +68,9 @@ public:
 
     void setWidget(QWidget *widget);
     QWidget *widget() const;
+
+    void setDciIcon(const DDciIcon &dciIcon);
+    DDciIcon dciIcon() const;
 };
 typedef QList<DViewItemAction *> DViewItemActionList;
 
@@ -135,6 +142,9 @@ public:
 
     void setFontSize(DFontSizeManager::SizeType size);
     QFont font() const;
+
+    void setDciIcon(const DDciIcon &dciIcon);
+    DDciIcon dciIcon() const;
 
     virtual QStandardItem *clone() const override;
 };


### PR DESCRIPTION
1. Add an interface to set the DCI icon in DListView.
2. Add drawing support for DCI icon in DStyledItemtDelegate.

Log:
Influence: None
Change-Id: If4ed076e8c2a819b28e5d046f885a22b6c0b8272