### PR TITLE
fix(build): invalid digit "8" in octal constant

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -7,10 +7,9 @@ DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 
 DEB_BUILD_ARCH ?= $(shell dpkg-architecture -qDEB_BUILD_ARCH)
 
-
 VERSION = $(DEB_VERSION_UPSTREAM)
 _PACK_VER = $(shell echo $(VERSION) | awk -F'[+_~-]' '{print $$1}')
-_BUILD_VER = $(shell echo $(VERSION) | awk -F'[+_~-]' '{print $$2}' | sed 's/[^0-9]//g')
+_BUILD_VER = $(shell echo $(VERSION) | awk -F'[+_~-]' '{print $$2}' | sed 's/[^0-9]//g' | awk '{print int($$1)}')
 ifeq ($(_BUILD_VER),)
 	CONFIG_VERSION = $(_PACK_VER)
 else


### PR DESCRIPTION
when BUILD_VERSION start with 0 was recognized as octal

Log:
Influence: debian build
Change-Id: Iad52d8f5622bf9035132242c0fb578e6e8d16992