### PR TITLE
fix: Edit focus blinks on right click

### DIFF
--- a/src/widgets/dlineedit.cpp
+++ b/src/widgets/dlineedit.cpp
@@ -521,7 +521,9 @@ bool DLineEdit::eventFilter(QObject *watched, QEvent *event)
         auto msg = QDBusMessage::createMethodCall("com.iflytek.aiassistant", "/",
                                        "org.freedesktop.DBus.Peer", "Ping");
         // 用之前 Ping 一下, 300ms 内没回复就认定是服务出问题，不再添加助手菜单项
-        auto pingReply = QDBusConnection::sessionBus().call(msg, QDBus::BlockWithGui, 300);
+        // Fix：Bug-154857 此处不能使用 BlockWithGui 否则右键事件会被处理，事件传递到
+        //  DSearchEdit 上会导致 edit 获得焦点然后菜单弹出后又失去焦点，有闪烁现象。。
+        auto pingReply = QDBusConnection::sessionBus().call(msg, QDBus::Block, 300);
         auto errorType = QDBusConnection::sessionBus().lastError().type();
         if (errorType == QDBusError::Timeout || errorType == QDBusError::NoReply) {
             qWarning() << pingReply << "\nwill not add aiassistant actions!";

--- a/src/widgets/dtextedit.cpp
+++ b/src/widgets/dtextedit.cpp
@@ -138,7 +138,7 @@ void DTextEdit::contextMenuEvent(QContextMenuEvent *e)
     auto msg = QDBusMessage::createMethodCall("com.iflytek.aiassistant", "/",
                                    "org.freedesktop.DBus.Peer", "Ping");
     // 用之前 Ping 一下, 300ms 内没回复就认定是服务出问题，不再添加助手菜单项
-    auto pingReply = QDBusConnection::sessionBus().call(msg, QDBus::BlockWithGui, 300);
+    auto pingReply = QDBusConnection::sessionBus().call(msg, QDBus::Block, 300);
     auto errorType = QDBusConnection::sessionBus().lastError().type();
     if (errorType == QDBusError::Timeout || errorType == QDBusError::NoReply) {
         qWarning() << pingReply << "\nwill not add aiassistant actions!";


### PR DESCRIPTION
when calling the dbus in BlockWithGui mode , the event will
be passed to the edit, causing the edit to gain focus, and
the edit will lose focus when the menu pops up.
so Let the bullets fly

Bug: https://pms.uniontech.com/bug-view-154857.html
Log:
Inlfluence: DSearchEdit-ContextMenu-Focus
Change-Id: Ic2ee354e78dd2f2382da3d8c7877926f465d1946