### PR TITLE
fix: DListView's size calculates error

### DIFF
--- a/src/widgets/dstyleditemdelegate.cpp
+++ b/src/widgets/dstyleditemdelegate.cpp
@@ -193,7 +193,7 @@ public:
         return DStyle::viewItemSize(style, &item, Qt::DisplayRole);
     }
 
-    static QList<QRect> doActionsLayout(QRect base, const QList<DViewItemAction*> &list, Qt::Orientation orientation,
+    static QList<QRect> doActionsLayout(QRect base, const DViewItemActionList &list, Qt::Orientation orientation,
                                         Qt::LayoutDirection direction, const QSize &fallbackIconSize, QSize *bounding)
     {
         if (list.isEmpty()) {
@@ -1038,10 +1038,10 @@ QSize DStyledItemDelegate::sizeHint(const QStyleOptionViewItem &option, const QM
 
     QSize size = (pixmapRect | textRect | checkRect).size();
 
-    const DViewItemActionList &left_actions = qvariant_cast<QList<DViewItemAction*>>(index.data(Dtk::LeftActionListRole));
-    const DViewItemActionList &right_actions = qvariant_cast<QList<DViewItemAction*>>(index.data(Dtk::RightActionListRole));
-    const DViewItemActionList &top_actions = qvariant_cast<QList<DViewItemAction*>>(index.data(Dtk::TopActionListRole));
-    const DViewItemActionList &bottom_actions = qvariant_cast<QList<DViewItemAction*>>(index.data(Dtk::BottomActionListRole));
+    const DViewItemActionList &left_actions = qvariantToActionList(index.data(Dtk::LeftActionListRole));
+    const DViewItemActionList &right_actions = qvariantToActionList(index.data(Dtk::RightActionListRole));
+    const DViewItemActionList &top_actions = qvariantToActionList(index.data(Dtk::TopActionListRole));
+    const DViewItemActionList &bottom_actions = qvariantToActionList(index.data(Dtk::BottomActionListRole));
 
     QSize action_area_size;
     // 获取左边区域大小


### PR DESCRIPTION
  miss to cast for QList<DViewItemAction*>,
only cast DViewItemActionList, it causes sizeHint calculates error.

Log: DListView的sizeHint计算错误导致各项堆叠
Bug:  https://pms.uniontech.com/bug-view-155683.html
Influence: 用到了DListView，并且使用到了DViewItemAction的所有应用
Change-Id: I13506bcfed970c9733a50130c92e421e71457805