### PR TITLE
fix: incompatible because of added clone function

### DIFF
--- a/src/widgets/dstyleditemdelegate.cpp
+++ b/src/widgets/dstyleditemdelegate.cpp
@@ -1454,9 +1454,4 @@ QFont DStandardItem::font() const
     return getViewItemFont(index(), Dtk::ViewItemFontLevelRole);
 }
 
-QStandardItem *DStandardItem::clone() const
-{
-    return new DStandardItem(*this);
-}
-
 DWIDGET_END_NAMESPACE

--- a/src/widgets/dstyleditemdelegate.h
+++ b/src/widgets/dstyleditemdelegate.h
@@ -135,8 +135,6 @@ public:
 
     void setFontSize(DFontSizeManager::SizeType size);
     QFont font() const;
-
-    virtual QStandardItem *clone() const override;
 };
 
 DWIDGET_END_NAMESPACE


### PR DESCRIPTION
  Add clone() override, it can't find DStandardItem::clone symbol
in some scene,
  for example, class A inherited DStandardItem, it compiled in
environment that has the symbol, and it run in not has symbol
environment.
  we can't use textActionList() and actionList() to get data
when draged with Action Item, because create a new QStandardItem
instead of DStandardItem, we should record the origin data ourselves.
  we can't use DVtableHook::overrideVfptrFun, we don't have
right time to override clone() function, because we don't implement
constructor.

Log: 添加重写的虚函数clone导致接口不兼容
Influence: 文管应用在高版本的dtkwidget下打包，低版本的dtkwidget下无法启动
Change-Id: I38da9ec4694a3c67510415989e516f5f977d4bf7