### PR TITLE
fix: UT error

### DIFF
--- a/tests/testcases/widgets/ut_dstyleditemdelegate.cpp
+++ b/tests/testcases/widgets/ut_dstyleditemdelegate.cpp
@@ -235,7 +235,7 @@ TEST_F(ut_DViewItemAction, actionDestoryByDStandItemWithClone)
     QPointer<DViewItemAction> actionPointer(new DViewItemAction());
     item->setActionList(Qt::RightEdge, {actionPointer});
 
-    DStandardItem *item2 = dynamic_cast<DStandardItem *>(item->clone());
+    QStandardItem *item2 = item->clone();
     delete item;
     ASSERT_TRUE(actionPointer);
     delete item2;


### PR DESCRIPTION
  we remove DStandardItem::clone due to incompatible in V23,
item->clone() call QStandardItem's function actually, so it
isn't a DStandardItem, but the clone's intention need to be test.
  it doesn't need to cherry-pick to master.

Log: 单元测试失败
Bug: https://pms.uniontech.com/bug-view-156901.html
Influence: 无
Change-Id: Ibac6bc721104bb0bc2f16c3a63a12fbc20e88f22