### PR TITLE
fix: FloatingButton Antialiasing doesn't obvious

### DIFF
--- a/src/widgets/dstyle.cpp
+++ b/src/widgets/dstyle.cpp
@@ -152,6 +152,8 @@ static QImage dropShadow(const QPixmap &px, qreal radius, const QColor &color)
     QImage tmp(px.size() + QSize(radius * 2, radius * 2), QImage::Format_ARGB32_Premultiplied);
     tmp.fill(0);
     QPainter tmpPainter(&tmp);
+    tmpPainter.setOpacity(0.3); // design requirement
+    tmpPainter.setRenderHint(QPainter::Antialiasing);
     tmpPainter.setCompositionMode(QPainter::CompositionMode_Source);
     tmpPainter.drawPixmap(QPoint(radius, radius), px);
     tmpPainter.end();
@@ -250,6 +252,7 @@ void drawShadow(QPainter *pa, const QRect &rect, qreal xRadius, qreal yRadius, c
 
         pa.setBrush(sc);
         pa.setPen(Qt::NoPen);
+        pa.setRenderHint(QPainter::Antialiasing);
         pa.drawRoundedRect(shadow_base.rect(), xRadius, yRadius);
         pa.end();
 
@@ -285,6 +288,7 @@ void drawShadow(QPainter *pa, const QRect &rect, const QPainterPath &path, const
     shadow_base.setDevicePixelRatio(scale);
 
     QPainter paTmp(&shadow_base);
+    paTmp.setRenderHint(QPainter::Antialiasing, true);
     paTmp.setBrush(sc);
     paTmp.setPen(Qt::NoPen);
     paTmp.drawPath(path);
@@ -1116,12 +1120,12 @@ void DStyle::drawPrimitive(const QStyle *style, DStyle::PrimitiveElement pe, con
                 shadow_rect.setHeight(qMin(shadow_rect.width(), shadow_rect.height()));
                 shadow_rect.moveCenter(opt->rect.center() + QPoint(shadow_xoffset / 2.0, shadow_yoffset / 2.0));
 
+                p->setRenderHint(QPainter::Antialiasing);
                 DDrawUtils::drawShadow(p, shadow_rect, frame_radius, frame_radius,
                                        DStyle::adjustColor(color, 0, 0, +30), shadow_radius, QPoint(0, 0));
 
                 p->setPen(Qt::NoPen);
                 p->setBrush(color);
-                p->setRenderHint(QPainter::Antialiasing);
                 p->drawEllipse(content_rect);
             } else if (btn->features & DStyleOptionButton::CircleButton) {
                 QRect content_rect = opt->rect;


### PR DESCRIPTION
  Add Anitialiasing flag when drawing FloatingButton's panel.

Log: 在绘制FloatingButton面板时添加抗锯齿属性
Bug: https://pms.uniontech.com/bug-view-153687.html 
Influence: 所有使用了FloatingButton和CE_FloatingWidget的应用， 都会减少阴影部分的锯齿

Change-Id: Iabca0e0b3f6b1d14e245e8386733dcb48b7e83c3