### PR TITLE
fix: error状态一开始就默认出现

### DIFF
--- a/src/widgets/dprintpreviewdialog.cpp
+++ b/src/widgets/dprintpreviewdialog.cpp
@@ -1729,6 +1729,7 @@ void DPrintPreviewDialogPrivate::_q_pageRangeChanged(int index)
         }
         if (pageRangeEdit->isAlert()) {
             pageRangeEdit->clear();
+            pageRangeEdit->setAlert(false);
             pageRangeEdit->lineEdit()->setPlaceholderText(qApp->translate("DPrintPreviewDialogPrivate", "For example, 1,3,5-7,11-15,18,21"));
         }
     }


### PR DESCRIPTION
初始化时setAlert为false

Log: 修复error状态一开始就默认出现问题
Bug: https://pms.uniontech.com/bug-view-158801.html
Influence: 打印预览页面范围输入状态
Change-Id: I47e5e5c0f8a8b082e973eb671dcab8208ca2e677