### PR TITLE
fix: 自定义水印文字问题

### DIFF
--- a/src/widgets/dprintpreviewdialog.cpp
+++ b/src/widgets/dprintpreviewdialog.cpp
@@ -814,8 +814,8 @@ void DPrintPreviewDialogPrivate::initWaterMarkui()
     settingHelper->setSubControlEnabled(DPrintPreviewSettingInterface::SC_Watermark_CustomText, false);
     waterTextEdit->lineEdit()->setMaxLength(16);
     waterTextEdit->lineEdit()->setPlaceholderText(qApp->translate("DPrintPreviewDialogPrivate", "Input your text"));
-    hlayout2->addWidget(new DLabel, 4);
-    hlayout2->addWidget(waterTextEdit, 9);
+    hlayout2->addStretch(5);
+    hlayout2->addWidget(waterTextEdit, 10);
 
     QHBoxLayout *hlayout3 = new QHBoxLayout;
     fontCombo = new DComboBox;
@@ -2020,6 +2020,7 @@ void DPrintPreviewDialogPrivate::_q_textWaterMarkModeChanged(int index)
             pview->setTextWaterMark(lastCusWatermarkText);
         }
     }
+    waterTextEdit->setVisible(index == waterTextCombo->count() - 1);
 }
 
 /*!


### PR DESCRIPTION
非自定义时，隐藏输入框;
自定义时，显示输入框。

Log: 修复自定义水印文字问题
Bug: https://pms.uniontech.com/bug-view-158803.html
Influence: 自定义水印输入框
Change-Id: Ibff01f401db9c93e773fe8f16755554a1256f547