### PR TITLE
fix: 打印预览页面设置间距不对

### DIFF
--- a/src/widgets/dprintpreviewdialog.cpp
+++ b/src/widgets/dprintpreviewdialog.cpp
@@ -479,7 +479,7 @@ void DPrintPreviewDialogPrivate::initadvanceui()
     QWidget *marginSpinWidget = new QWidget(q);
     marginSpinWidget->setObjectName(_d_printSettingNameMap[DPrintPreviewSettingInterface::SC_Margin_AdjustContol]);
     QHBoxLayout *marginsspinlayout = new QHBoxLayout(marginSpinWidget);
-    marginsspinlayout->setContentsMargins(0, 0, 0, 0);
+
     DLabel *toplabel = new DLabel(qApp->translate("DPrintPreviewDialogPrivate", "Top"));
     marginTopSpin = new DDoubleSpinBox;
     marginTopSpin->installEventFilter(q);
@@ -514,7 +514,9 @@ void DPrintPreviewDialogPrivate::initadvanceui()
     marginsspinlayout->addLayout(marginsspinboxlayout1);
     marginsspinlayout->addLayout(marginslabellayout2);
     marginsspinlayout->addLayout(marginsspinboxlayout2);
+    marginslayout->setSpacing(0);
     marginslayout->addLayout(marginscombolayout);
+    marginslayout->addSpacing(10);
     marginslayout->addWidget(marginSpinWidget);
 
     QRegExp reg("^([5-5][0-4]|[1-4][0-9]|[0-9])?(\\.[0-9][0-9])|55(\\.[8-8][0-8])|55(\\.[0-7][0-9])");


### PR DESCRIPTION
设置打印预览页边距UI的间距为10px

Log: 修复页面设置间距不对的问题
Bug: https://pms.uniontech.com/bug-view-158805.html
Influence: 打印预览页边距UI
Change-Id: I3553112e875a924cd1b322384c04a722ec48727b