### PR TITLE
chore: 使用 *.ts 添加翻译文件

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,9 +51,8 @@ foreach(FILENAME ${CONFIGSOURCE})
   file(APPEND ${CONFIGNAME} "#define DTKWIDGET_CLASS_${thefile}\n")
 endforeach()
 
-file(GLOB TRANSLATE translations/*)
+file(GLOB TRANSLATE translations/*.ts)
 qt5_add_translation(TRANSLATEDFILES ${TRANSLATE})
-
 
 add_definitions(-DSN_API_NOT_YET_FROZEN)
 add_definitions(-DDTK_NO_MULTIMEDIA)


### PR DESCRIPTION
原来使用 qmake 时，生成的 qm 文件在 src/translations 下
切换分支后，使用 src/translations/* 会重复生成相同的 qm 文件，
需要主动删除一下qm文件才可以(如 git clean -dfx)，否则报错
CMake Error at Qt5LinguistToolsMacros.cmake:105 (add_custom_command): Attempt to add a custom rule to output which already has a custom rule.

Log: none
Influence: cmake build
Change-Id: I089403b4f0406baa4f97e1270f5d092256f97fb2