### PR TITLE
chore: wayland下分屏窗口在暗主题上异常

### DIFF
--- a/src/widgets/darrowrectangle.cpp
+++ b/src/widgets/darrowrectangle.cpp
@@ -479,7 +479,8 @@ void DArrowRectangle::setBackgroundColor(const QColor &backgroundColor)
 
     d->m_backgroundColor = backgroundColor;
 
-    if ((d->m_handle || isDwayland()) && d->m_backgroundColor.toRgb().alpha() < 255) {
+    bool isFloatWindow = d->floatMode == FloatWindow;
+    if ((d->m_handle || (isFloatWindow && isDwayland())) && d->m_backgroundColor.toRgb().alpha() < 255) {
         if (!d->m_blurBackground) {
             d->m_blurBackground = new DBlurEffectWidget(this);
             d->m_blurBackground->setBlendMode(DBlurEffectWidget::BehindWindowBlend);


### PR DESCRIPTION
setBackgroundColor里面增加个isFloatWindow的判断

Log: 修复wayland下分屏窗口在暗主题上异常问题
Influence: 分屏窗口UI
Change-Id: Icc2819bc2d3033b6233ce523336daa236683e003