### PR TITLE
chore: 打印预览页面范围输入框调整

### DIFF
--- a/src/widgets/dprintpreviewdialog.cpp
+++ b/src/widgets/dprintpreviewdialog.cpp
@@ -1708,6 +1708,7 @@ void DPrintPreviewDialogPrivate::_q_printerChanged(int index)
 void DPrintPreviewDialogPrivate::_q_pageRangeChanged(int index)
 {
     setEnable(index, pageRangeCombo);
+    pageRangeEdit->setVisible(index == DPrintPreviewWidget::SelectPage);
     pageRangeEdit->lineEdit()->setPlaceholderText("");
     pageRangeEdit->setText("");
     if (index == DPrintPreviewWidget::AllPage || index == DPrintPreviewWidget::CurrentPage) {


### PR DESCRIPTION
当页面范围是All或Current Page, 隐藏输入框；
当页面范围是Select Pages, 显示输入框。

Log:
Influence: 打印预览-页面范围输入框
Change-Id: Ic33c920a7f279ddeaf3d6703a42918892b706f12