### PR TITLE
fix: 打印预览水印项的圆角和其他项的不一致

### DIFF
--- a/src/widgets/dprintpreviewdialog.cpp
+++ b/src/widgets/dprintpreviewdialog.cpp
@@ -799,13 +799,14 @@ void DPrintPreviewDialogPrivate::initWaterMarkui()
     vContentLayout->setContentsMargins(0, 5, 0, 5);
     vContentLayout->setSpacing(10);
     QVBoxLayout *vWatertypeLayout = new QVBoxLayout;
+    vWatertypeLayout->setContentsMargins(0, 0, 0, 0);
     textWatermarkWdg = new DWidget;
     picWatermarkWdg = new DWidget;
     vWatertypeLayout->addWidget(textWatermarkWdg);
     vWatertypeLayout->addWidget(picWatermarkWdg);
 
     QVBoxLayout *textVlayout = new QVBoxLayout;
-    textVlayout->setContentsMargins(0, 0, 5, 0);
+    textVlayout->setContentsMargins(9, 9, 14, 9);
     QHBoxLayout *hlayout1 = new QHBoxLayout;
     DRadioButton *textBtn = new DRadioButton(qApp->translate("DPrintPreviewDialogPrivate", "Text watermark"));
     waterTextCombo = new DComboBox;
@@ -844,7 +845,7 @@ void DPrintPreviewDialogPrivate::initWaterMarkui()
     textWatermarkWdg->setLayout(textVlayout);
 
     QHBoxLayout *picHlayout = new QHBoxLayout;
-    picHlayout->setContentsMargins(0, 0, 5, 0);
+    picHlayout->setContentsMargins(9, 9, 14, 9);
     DRadioButton *picBtn = new DRadioButton(qApp->translate("DPrintPreviewDialogPrivate", "Picture watermark"));
     picPathEdit = new DFileChooserEdit;
     picPathEdit->setObjectName(_d_printSettingNameMap[DPrintPreviewSettingInterface::SC_Watermark_ImageEdit]);


### PR DESCRIPTION
原因：DBackgroundGroup的layout未设置margin为0，
      DBackgroundGroup的默认itemMargin为9，
      影响其圆角大小。
修改：设置DBackgroundGroup的layout的margin为0，在其子widget里设置margin。

Log: 修复打印预览水印项的圆角和其他项的不一致问题
Bug: https://pms.uniontech.com/bug-view-158803.html
Influence: 打印预览水印项UI
Change-Id: I88497151148d1f2c9e19e3192661275528bb5be0