### PR TITLE
fix: 移动窗口后控件失去了 hover 状态

### DIFF
--- a/src/widgets/dapplication.cpp
+++ b/src/widgets/dapplication.cpp
@@ -59,6 +59,8 @@
 #define DXCB_PLUGIN_SYMBOLIC_PROPERTY "_d_isDxcb"
 #define QT_THEME_CONFIG_PATH "D_QT_THEME_CONFIG_PATH"
 
+extern QWidget *qt_button_down;
+
 DCORE_USE_NAMESPACE
 
 DWIDGET_BEGIN_NAMESPACE
@@ -1491,6 +1493,13 @@ bool DApplication::notify(QObject *obj, QEvent *event)
     if (event->type() == QEvent::ApplicationFontChange) {
         // ApplicationFontChange 调用 font() 是 ok 的，如果在 fontChanged 中调用在某些版本中会出现 deadlock
         DFontSizeManager::instance()->setFontGenericPixelSize(static_cast<quint16>(DFontSizeManager::fontPixelSize(font())));
+    }
+
+    if (QEvent::MouseMove == event->type() && qt_button_down) {
+        QMouseEvent *me = static_cast<QMouseEvent*>(event);
+        if (!me->buttons()) {
+            qt_button_down = nullptr;
+        }
     }
 
     return QApplication::notify(obj, event);


### PR DESCRIPTION
通过窗口管理器移动窗口时，鼠标按下并移动，之后事件由窗管接管
移动结束后，应用无法收到鼠标释放的事件，导致没有刷新全局的 qt_button_down
此时 sendMouseEvent 无法走到 dispatchEnterLeave 即没有 enter/leave 事件触发，也就没有了 hover 状态。收到 mouse move 且没有鼠标按下的状态时
置空 qt_button_down

Log: 修复移动窗口后控件的hover状态丢失问题
Change-Id: I0fcb8794a9c38e3d0928b976baffb25f0ef70958