### PR TITLE
fix: qcommandlinkbutton 主题

### DIFF
--- a/src/widgets/dstyle.cpp
+++ b/src/widgets/dstyle.cpp
@@ -2239,6 +2239,9 @@ QIcon DStyle::standardIcon(QStyle::StandardPixmap st, const QStyleOption *opt, c
         CASE_ICON(TitleQuitFullButton)
     case SP_LineEditClearButton:
         return QIcon::fromTheme("button_edit-clear");
+    case SP_CommandLink:
+            return QIcon::fromTheme(QLatin1String("go-next"),
+                                    QIcon::fromTheme(QLatin1String("forward")));
     default:
         break;
     }


### PR DESCRIPTION
QCommandLinkButton在qt源码中进行了一次pixmap变换，这导致前端拿不到位图
这里将QCommandLinkButton 的icon直接返回了QIcon theme,避免了pixmap的变换

Log: qcommandlinkbutton 的高分屏模糊bug
Influence: qcommandlinkbutton
