### PR TITLE
fix: 打印预览页面打开“添加水印”开关后再关闭，水印开关消失

### DIFF
--- a/src/widgets/dprintpreviewdialog.cpp
+++ b/src/widgets/dprintpreviewdialog.cpp
@@ -98,6 +98,7 @@ static QLatin1String _d_printSettingNameMap[DPrintPreviewSettingInterface::SC_Co
     QLatin1String("MarginsAdjustWidget"),
     QLatin1String("ScalingContentBackgroundGroup"),
     QLatin1String("WaterMarkFrame"),
+    QLatin1String("WaterMarkContentFrame"),
     QLatin1String("WaterMarkTypeBackgroundGroup"),
     QLatin1String("WaterMarkTextTypeComboBox"),
     QLatin1String("WaterMarkCustomTextEdit"),
@@ -768,7 +769,7 @@ void DPrintPreviewDialogPrivate::initadvanceui()
     watermarkframe->setLayout(texttypelayout);
 
     watermarksettingwdg = new DWidget;
-    watermarksettingwdg->setObjectName(_d_printSettingNameMap[DPrintPreviewSettingInterface::SC_WatermarkWidget]);
+    watermarksettingwdg->setObjectName(_d_printSettingNameMap[DPrintPreviewSettingInterface::SC_WatermarkContentWidget]);
     watermarksettingwdg->setMinimumWidth(WIDTH_NORMAL);
     initWaterMarkui();
     watermarksettingwdg->hide();
@@ -2069,14 +2070,14 @@ void DPrintPreviewDialogPrivate::waterMarkBtnClicked(bool checked)
 {
     if (checked) {
         wmSpacer->changeSize(WIDTH_NORMAL, SPACER_HEIGHT_HIDE);
-        settingHelper->setSubControlVisible(DPrintPreviewSettingInterface::SC_WatermarkWidget, true);
+        settingHelper->setSubControlVisible(DPrintPreviewSettingInterface::SC_WatermarkContentWidget, true);
         waterTypeGroup->button(typeChoice)->setChecked(true);
         watermarkTypeChoosed(typeChoice);
         if (typeChoice == Type_Image - 1 && !picPathEdit->text().isEmpty())
             customPictureWatermarkChoosed(picPathEdit->text());
     } else {
         wmSpacer->changeSize(WIDTH_NORMAL, SPACER_HEIGHT_SHOW);
-        settingHelper->setSubControlVisible(DPrintPreviewSettingInterface::SC_WatermarkWidget, false);
+        settingHelper->setSubControlVisible(DPrintPreviewSettingInterface::SC_WatermarkContentWidget, false);
         pview->setWaterMarkType(Type_None);
     }
 }

--- a/src/widgets/dprintpreviewsettinginterface.h
+++ b/src/widgets/dprintpreviewsettinginterface.h
@@ -39,6 +39,7 @@ public:
         SC_Margin_AdjustContol,
         SC_ScalingWidget,
         SC_WatermarkWidget,
+        SC_WatermarkContentWidget,
         SC_Watermark_TypeGroup,
         SC_Watermark_TextType,
         SC_Watermark_CustomText,


### PR DESCRIPTION
原因：根据对象名字关闭控件，开关和下面功能控件一个对象名。
解决：增加一个对象名字控制下面的功能控件。

Log: 修复打印预览页面打开“添加水印”开关后再关闭，水印开关消失问题
Bug: https://pms.uniontech.com/bug-view-163737.html
Influence: 水印
Change-Id: I02358adf9c64a50434d924d9da06748e32b6f15d