### PR TITLE
fix: shotcuts show in context menu

### DIFF
--- a/src/widgets/dapplication.cpp
+++ b/src/widgets/dapplication.cpp
@@ -547,6 +547,9 @@ DApplication::DApplication(int &argc, char **argv) :
         setAttribute(Qt::AA_ForceRasterWidgets);
     }
 
+    if (!qEnvironmentVariableIsSet("D_DTK_SHOWSHORTCUTSINCONTEXTMENUS"))
+        setAttribute(Qt::AA_DontShowShortcutsInContextMenus);
+
 #ifdef Q_OS_LINUX
     // set qpixmap cache limit
     if (QGSettings::isSchemaInstalled("com.deepin.dde.dapplication"))


### PR DESCRIPTION
Don't show shortcuts in context menu
QDeepinTheme::themeHint(ShowShortcutsInContextMenus) return false not work anymore
see https://codereview.qt-project.org/c/qt/qtbase/+/351295

Bug: https://pms.uniontech.com/bug-view-167667.html
Log: Don't Show Shortcuts In Context Menus
Change-Id: Ifc08b39d9b4b6b15d66c3e07fd41443b93d48b27