### PR TITLE
fix: 搜索框文字没有居中

### DIFF
--- a/src/widgets/dsearchedit.cpp
+++ b/src/widgets/dsearchedit.cpp
@@ -332,6 +332,7 @@ void DSearchEditPrivate::init()
 
     center_layout->addWidget(iconbtn, 0, Qt::AlignVCenter);
     center_layout->addWidget(label, 0, Qt::AlignCenter);
+    center_layout->addSpacing(12 / qApp->devicePixelRatio());
     layout->addWidget(iconWidget, 0, Qt::AlignCenter);
 
     QAction* clearAction = q->lineEdit()->findChild<QAction *>(QLatin1String("_q_qlineeditclearaction"));


### PR DESCRIPTION
搜索框文字偏左12px

Log: 修复搜索框文字没有居中问题
Bug: https://pms.uniontech.com/bug-view-167567.html
Influence: 搜索框
Change-Id: I8ca4b6eb019da4fbe93ddcb7a612242c6403cd77