### PR TITLE
fix: DTitleBar exists incompatible modify

### DIFF
--- a/src/widgets/dtitlebar.cpp
+++ b/src/widgets/dtitlebar.cpp
@@ -1160,12 +1160,8 @@ void DTitlebar::showMenu()
 {
     D_D(DTitlebar);
 
-#ifndef QT_NO_MENU
-    // 默认菜单应该是showmenu之前添加, 而非showevent
-    d->_q_addDefaultMenuItems();
-#endif
-     if (d->helpAction)
-         d->helpAction->setVisible(DApplicationPrivate::isUserManualExists());
+    if (d->helpAction)
+        d->helpAction->setVisible(DApplicationPrivate::isUserManualExists());
 
     if (d->menu) {
         // 更新主题选中的项
@@ -1208,6 +1204,11 @@ void DTitlebar::showEvent(QShowEvent *event)
     d->separatorTop->move(0, 0);
     d->separator->setFixedWidth(width());
     d->separator->move(0, height() - d->separator->height());
+
+#ifndef QT_NO_MENU
+    // 默认菜单需要在showevent添加，否则`menu`接口返回空actions，导致接口逻辑不兼容
+    d->_q_addDefaultMenuItems();
+#endif
 
     QWidget::showEvent(event);
 


### PR DESCRIPTION
  old dtkwidget assume menu is not empty, but now it's not, and
we revert this code.
  Moving addDefaultMenuItems from `showMenu` to `showEvent`,
because some applications get menuItems and assert they are not empty before  `showMenu`.
  delay to check UserManual avoid to request dbus in `showEvent`.

Log: 升级后DTitleBar提供的menu可能没有默认菜单项，导致部分应用异常，改回
原来版本的逻辑
Bug: https://pms.uniontech.com/bug-view-170639.html Influence: 升级dtkwidget导致包管理器使用安装功能时崩溃

Change-Id: Ifae616c8ba5af3a2e28b1dbb00009e0a2872a989