### PR TITLE
fix: DStyleItemDelegate filter ListView's event

### DIFF
--- a/src/widgets/dstyleditemdelegate.cpp
+++ b/src/widgets/dstyleditemdelegate.cpp
@@ -869,7 +869,6 @@ DStyledItemDelegate::DStyledItemDelegate(QAbstractItemView *parent)
 {
     //支持QAction的点击
     parent->viewport()->installEventFilter(this);
-    parent->installEventFilter(this);
 
     // 初始化 background type. 注意 setBackgroundType() 中有额外的处理操作，所以不能直接简单的修改默认值
     setBackgroundType(DStyledItemDelegate::RoundedBackground);
@@ -1396,7 +1395,8 @@ bool DStyledItemDelegate::eventFilter(QObject *object, QEvent *event)
     default:
         break;
     }
-    if (object == parent()) {
+    const auto view = qobject_cast<QAbstractItemView*>(parent());
+    if (view && object == view->viewport()) {
         static const QEvent::Type UpdateWidgetVisibleEvent(
                     static_cast<QEvent::Type>(QEvent::registerEventType()));
 
@@ -1404,7 +1404,7 @@ bool DStyledItemDelegate::eventFilter(QObject *object, QEvent *event)
             D_D(DStyledItemDelegate);
             if (d->readyRecordVisibleWidgetOfCurrentFrame()) {
                 auto updateEvent = new QEvent(UpdateWidgetVisibleEvent);
-                qApp->postEvent(parent(), updateEvent);
+                qApp->postEvent(view->viewport(), updateEvent);
             }
         } else if (event->type() == UpdateWidgetVisibleEvent) {
             D_D(DStyledItemDelegate);


### PR DESCRIPTION
  QStyledItemDelagate::eventFilter can filter the object's Tab
key event, here We only need a Paint Event to post UpdateWidgetVisibleEvent, and updateWidgetVisible, so we remove the eventFilter of AbstractItemView

Log: DStyleItemDelegate拦截了QListView的部分事件，导致listview的Tab 事件和焦点异常
Bug: https://pms.uniontech.com/bug-view-164547.html Influence: 使用了DListView的应用，其listview的tab键，焦点事件可能
异常，

Change-Id: I1d4d8c836b5c6b27e021a5d632b969daf3f5b348