### PR TITLE
fix: 打印文件设置纸张大小不生效

### DIFF
--- a/src/widgets/dprintpreviewdialog.cpp
+++ b/src/widgets/dprintpreviewdialog.cpp
@@ -2147,7 +2147,7 @@ void DPrintPreviewDialogPrivate::matchFitablePageSize()
     if (isActualPrinter(printDeviceCombo->currentText())) {
         auto const &pageSizes = prInfo.supportedPageSizes();
         auto it = std::find_if(pageSizes.cbegin(), pageSizes.cend(), [&](const QPageSize &pageSize) {
-            return pageSize.key() == paperSizeCombo->currentText();
+            return pageSize.name() == paperSizeCombo->currentText();
         });
 
         if (it != pageSizes.end())


### PR DESCRIPTION
原因：匹配的是key字段，实际combobox内容是name字段
修改: 将匹配的key字段修改成name字段

Log: 修复打印文件设置纸张大小不生效
Bug: https://pms.uniontech.com/bug-view-171767.html
Influence: 打印纸张大小
Change-Id: I557072ca5592059031a71c4bbb4bb8e1ecabe154