### PR TITLE
更新topic仓库

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dtkwidget (5.6.3.8) unstable; urgency=medium
+
+  * Release 5.6.3.8
+
+ -- Deepin Packages Builder <packages@deepin.com>  Tue, 20 Dec 2022 11:43:32 +0800
+
 dtkwidget (5.6.3) unstable; urgency=medium
 
   * Release 5.6.3


### PR DESCRIPTION
update changelog

临时tag，更新而不合并，大版本号还是 5.6.3

Log: update changelog
Influence: none
Change-Id: I65fa0d9e61189f95a70cb19bb766411b7a432070