### PR TITLE
fix: correct default constructor for DStyleHelper

### DIFF
--- a/include/dtkwidget/widgets/dstyle.h
+++ b/include/dtkwidget/widgets/dstyle.h
@@ -13,6 +13,7 @@
 #include <QPainter>
 #include <QIconEngine>
 #include <QStyleOption>
+#include <QApplication>
 
 QT_BEGIN_NAMESPACE
 class QTextLayout;
@@ -301,7 +302,7 @@ public:
 class DStyleHelper
 {
 public:
-    inline DStyleHelper(const QStyle *style = nullptr) {
+    inline DStyleHelper(const QStyle *style = QApplication::style()) {
         setStyle(style);
     }
 


### PR DESCRIPTION
Modify default value for m_style of DStyleHelper from nullptr to QApplication::style in case we have a stack overflow.

Log: correct default constructor for DStyleHelper