### PR TITLE
fix: 增加titlebarSettingsImpl空指针判断

### DIFF
--- a/src/widgets/dtitlebar.cpp
+++ b/src/widgets/dtitlebar.cpp
@@ -666,7 +666,7 @@ void DTitlebarPrivate::_q_addDefaultMenuItems()
     }
 
     // add toolbarAction menu item for deepin or uos application
-    if (titlebarSettingsImpl->isValid() && !toolbarAction) {
+    if (titlebarSettingsImpl && titlebarSettingsImpl->isValid() && !toolbarAction) {
         toolbarAction = new QAction(qApp->translate("TitleBarMenu", "TitlebarSettings"), menu);
         toolbarAction->setObjectName("TitlebarSettings");
         QObject::connect(toolbarAction, SIGNAL(triggered(bool)), q, SLOT(_q_toolBarActionTriggerd()));


### PR DESCRIPTION
新建dtitlebar对象，未调用settings()，titlebarSettingsImpl是空的

Log: 增加titlebarSettingsImpl空指针判断
Influence: dtitlebar
Change-Id: I6f330f59556b86b34e94c8cb8997556c7bb59e8e