### PR TITLE
fix: 二次调起特性对话框崩溃

### DIFF
--- a/src/widgets/dapplication.cpp
+++ b/src/widgets/dapplication.cpp
@@ -1111,7 +1111,12 @@ DFeatureDisplayDialog *DApplication::featureDisplayDialog()
 {
     D_D(DApplication);
     if (d->featureDisplayDialog == nullptr) {
-        d->featureDisplayDialog = new DFeatureDisplayDialog(activeWindow());
+        d->featureDisplayDialog = new DFeatureDisplayDialog();
+        connect(this, &DApplication::aboutToQuit, this, [this]{
+            D_D(DApplication);
+            d->featureDisplayDialog->deleteLater();
+            d->featureDisplayDialog = nullptr;
+        });
     }
     return d->featureDisplayDialog;
 }

--- a/src/widgets/dfeaturedisplaydialog.cpp
+++ b/src/widgets/dfeaturedisplaydialog.cpp
@@ -9,6 +9,7 @@
 #include <DFontSizeManager>
 #include <DGuiApplicationHelper>
 
+#include <QApplication>
 #include <QLabel>
 #include <QHBoxLayout>
 #include <QVBoxLayout>
@@ -326,6 +327,10 @@ void DFeatureDisplayDialog::show()
     d->createWidgetItems();
     d->updateItemWidth();
     DDialog::show();
+    if (QWidget* window = qApp->activeWindow()) {
+        const auto point(window->mapToGlobal(window->rect().topLeft()));
+        moveToCenterByRect(QRect(point.x(), point.y(), window->rect().width(), window->rect().height()));
+    }
 }
 
 DWIDGET_END_NAMESPACE

--- a/src/widgets/dmainwindow.cpp
+++ b/src/widgets/dmainwindow.cpp
@@ -139,15 +139,6 @@ void DMainWindowPrivate::_q_autoShowFeatureDialog()
     D_QC(DMainWindow);
     if (q->windowHandle()->isActive()) {
         qApp->featureDisplayDialog()->show();
-        const QPoint pos = q->pos();
-        QRect rect;
-        for (QScreen *screen : qApp->screens()) {
-            if (screen->geometry().contains(pos)) {
-                rect = screen->geometry();
-                break;
-            }
-        }
-        qApp->featureDisplayDialog()->moveToCenterByRect(rect);
         q->disconnect(q->windowHandle(), SIGNAL(activeChanged()), q, SLOT(_q_autoShowFeatureDialog()));
     }
 }


### PR DESCRIPTION
原因：特性对话框的父窗口是关于对话框时，
      随着关于对话框销毁，再次访问特性对话框对象就会崩溃。
修改：1.特性对话框不设置父窗口，随着应用退出销毁。
      2.特性对话框展示时，调整位置。

Log: 修复二次调起特性对话框崩溃问题
Influence: 特性对话框
Change-Id: I56671745ae6fb087133c34fcd50f54d4b9789e81