### PR TITLE
fix: the entrance of feature display is visible when no item is added

### DIFF
--- a/include/widgets/dfeaturedisplaydialog.h
+++ b/include/widgets/dfeaturedisplaydialog.h
@@ -48,6 +48,7 @@ public:
     void setLinkButtonVisible(bool isVisible);
     void setLinkUrl(const QString &url);
     void show();
+    bool isEmpty() const;
 
 private:
     D_DECLARE_PRIVATE(DFeatureDisplayDialog)

--- a/src/widgets/daboutdialog.cpp
+++ b/src/widgets/daboutdialog.cpp
@@ -1,8 +1,9 @@
-// SPDX-FileCopyrightText: 2017 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2017 - 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
 #include "daboutdialog.h"
+#include "dfeaturedisplaydialog.h"
 #include "private/daboutdialog_p.h"
 
 #include <dwidgetutil.h>
@@ -113,6 +114,7 @@ void DAboutDialogPrivate::init()
     featureLabel = new QLabel(websiteLinkTemplate.arg(websiteLink).arg(QObject::tr("Features")));
     featureLabel->setContextMenuPolicy(Qt::NoContextMenu);
     featureLabel->setOpenExternalLinks(false);
+    featureLabel->setVisible(!qApp->featureDisplayDialog()->isEmpty());
     redPointLabel = new DRedPointLabel();
     redPointLabel->setFixedSize(10, 10);
     QHBoxLayout *vFeatureLayout =  new QHBoxLayout;

--- a/src/widgets/dfeaturedisplaydialog.cpp
+++ b/src/widgets/dfeaturedisplaydialog.cpp
@@ -333,5 +333,11 @@ void DFeatureDisplayDialog::show()
     }
 }
 
+bool DFeatureDisplayDialog::isEmpty() const
+{
+    Q_D(const DFeatureDisplayDialog);
+    return d->m_featureItems.isEmpty();
+}
+
 DWIDGET_END_NAMESPACE
 #include "moc_dfeaturedisplaydialog.cpp"


### PR DESCRIPTION
 the entrance of feature display is visible when no item is added

when no feature item is added, hide the entrance in about daboutdialog

Log: fix the issue about feature dialog has no content
Influence: feature display
Change-Id: Id13ce0b84ede3d084f219cfbd35e1d2a94e3b4bc