### PR TITLE
fix: DStyleOptionButton's incompatible

### DIFF
--- a/src/widgets/dfloatingbutton.cpp
+++ b/src/widgets/dfloatingbutton.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2017 - 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -68,9 +68,6 @@ void DFloatingButton::initStyleOption(DStyleOptionButton *option) const
 {
     DIconButton::initStyleOption(option);
     option->features = QStyleOptionButton::ButtonFeature(DStyleOptionButton::FloatingButton);
-
-    if (!option->dciIcon.isNull())
-        option->features |= QStyleOptionButton::ButtonFeature(DStyleOptionButton::HasDciIcon);
 }
 
 DWIDGET_END_NAMESPACE

--- a/src/widgets/dstyle.cpp
+++ b/src/widgets/dstyle.cpp
@@ -1456,7 +1456,8 @@ void DStyle::drawControl(const QStyle *style, DStyle::ControlElement ce, const Q
             DStyleHelper dstyle(style);
             dstyle.drawControl(CE_ButtonBoxButtonBevel, btn, p, w);
             DStyleOptionButton subopt = *btn;
-            subopt.dciIcon = btn->dciIcon;
+            if (btn->features & DStyleOptionButton::HasDciIcon)
+                subopt.dciIcon = btn->dciIcon;
             subopt.rect = dstyle.subElementRect(SE_ButtonBoxButtonContents, btn, w);
             dstyle.drawControl(CE_ButtonBoxButtonLabel, &subopt, p, w);
             if ((btn->state & State_HasFocus)) {


### PR DESCRIPTION
  It was introduced in e4fdfe5b3683f0d68110b94dc98521de691f941f .
  It cause incompatible that DStyleOptionButton add a member
variable `dciIcon`.
  App is crashed if libdtkwidget5 is different between App built
and running loaded, (app builds with 5.5, but loads 5.6 version).
  We shouldn't add member variable that defined in .h and which
breaks abi.
  If this case has exist, we can Use DApplication::builtDtkVersion()
to avoid to accessing the member in some lower version.
  We are lucky, because we have `features` to avoid to accessing
`dciIcon` member in lower version.
  FloatingButton doesn't need add DciIcon to features, because
DDciIcon has execute this code.

Log: none
Influence: App crash in some case
Change-Id: Iff4d596c6f90fa82f0d93ec9db0118d8d0bffa40