### PR TITLE
fix: background widget is always shown when sidebar is hidden

### DIFF
--- a/src/widgets/dmainwindow.cpp
+++ b/src/widgets/dmainwindow.cpp
@@ -234,6 +234,7 @@ int DMainWindow::sidebarWidth() const
     D_DC(DMainWindow);
     if (d->sidebarHelper)
         return d->sidebarHelper->width();
+    return 0;
 }
 
 void DMainWindow::setSidebarWidth(int width)
@@ -247,7 +248,8 @@ bool DMainWindow::sidebarVisble() const
 {
     D_DC(DMainWindow);
     if (d->sidebarHelper)
-        return d->sidebarHelper->visble();
+        return d->sidebarHelper->visible();
+    return false;
 }
 
 void DMainWindow::setSidebarVisible(bool visible)
@@ -262,6 +264,7 @@ bool DMainWindow::sidebarExpanded() const
     D_DC(DMainWindow);
     if (d->sidebarHelper)
         return d->sidebarHelper->expanded();
+    return false;
 }
 
 void DMainWindow::setSidebarExpanded(bool expended)

--- a/src/widgets/dtitlebar.cpp
+++ b/src/widgets/dtitlebar.cpp
@@ -1257,7 +1257,6 @@ void DTitlebar::setSidebarHelper(DSidebarHelper *helper)
         d->sidebarBackgroundWidget->lower();
         d->leftLayout->addWidget(d->expandButton, 0, Qt::AlignLeft);
         connect(d->expandButton, &DIconButton::clicked, [this, d] (bool isExpanded) {
-            d->sidebarBackgroundWidget->setVisible(isExpanded);
             d->sidebarHelper->setExpanded(isExpanded);
             int x = isExpanded ? d->sidebarHelper->width() : 0;
             d->separator->move(x, height() - d->separator->height());
@@ -1268,11 +1267,10 @@ void DTitlebar::setSidebarHelper(DSidebarHelper *helper)
     }
 
     connect(helper, &DSidebarHelper::visibleChanged, this, [this](bool visible){
-        qInfo() << "visibleChanged" << visible;
         d_func()->expandButton->setVisible(visible);
     });
-    connect(helper, &DSidebarHelper::expandChanged, this, [](bool expanded){
-        qInfo() << "expandChanged" << expanded;
+    connect(helper, &DSidebarHelper::expandChanged, this, [this](bool isExpanded){
+        d_func()->sidebarBackgroundWidget->setVisible(isExpanded);
     });
     connect(helper, &DSidebarHelper::backgroundColorChanged, this, [](QColor backgroundColor){
         qInfo() << "backgroundColorChanged" << backgroundColor.name(QColor::NameFormat::HexArgb);

--- a/src/widgets/private/dmainwindow_p.h
+++ b/src/widgets/private/dmainwindow_p.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2017 - 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -18,7 +18,7 @@ DWIDGET_BEGIN_NAMESPACE
 class DSidebarHelper : public QObject
 {
     Q_OBJECT
-    Q_PROPERTY(bool visible READ visble WRITE setVisible NOTIFY visibleChanged)
+    Q_PROPERTY(bool visible READ visible WRITE setVisible NOTIFY visibleChanged)
     Q_PROPERTY(bool expanded READ expanded WRITE setExpanded NOTIFY expandChanged)
     Q_PROPERTY(int width READ width WRITE setWidth NOTIFY widthChanged)
     Q_PROPERTY(QColor backgroundColor READ backgroundColor WRITE setBackgroundColor NOTIFY backgroundColorChanged)
@@ -40,7 +40,7 @@ public:
         Q_EMIT backgroundColorChanged(m_backgroundColor);
     }
 
-    bool visble() const
+    bool visible() const
     {
         return m_visible;
     }


### PR DESCRIPTION
change background widget's visibility when the signal of expandChanged is emitted

Log: resolve the issue that background widget is always shown when sidebar is hidden
Influence: sidebar
Change-Id: I0a2fc73614aecfb736f52f00cb6ca07459f48fb7