### PR TITLE
chore: rename sidebarVisble to sidebarVisible

### DIFF
--- a/include/widgets/dmainwindow.h
+++ b/include/widgets/dmainwindow.h
@@ -47,7 +47,8 @@ public:
     int  sidebarWidth() const;
     void setSidebarWidth(int width);
 
-    bool sidebarVisble() const;
+    D_DECL_DEPRECATED_X("Please use sidebarVisible") bool sidebarVisble() const;
+    bool sidebarVisible() const ;
     void setSidebarVisible(bool visible);
 
     bool sidebarExpanded() const;

--- a/src/widgets/dmainwindow.cpp
+++ b/src/widgets/dmainwindow.cpp
@@ -246,6 +246,11 @@ void DMainWindow::setSidebarWidth(int width)
 
 bool DMainWindow::sidebarVisble() const
 {
+    return sidebarVisible();
+}
+
+bool DMainWindow::sidebarVisible() const
+{
     D_DC(DMainWindow);
     if (d->sidebarHelper)
         return d->sidebarHelper->visible();


### PR DESCRIPTION
obsolete old interface sidebarVisible due to spelling mistake

Log: rename sidebarVisble to sidebarVisible
Influence: sidebar
Change-Id: I7c932f4fc8f43db2271d3562d446b4f663e11ad4