### PR TITLE
fix: DStyleOptionButton's incompatible

### DIFF
--- a/include/widgets/dstyleoption.h
+++ b/include/widgets/dstyleoption.h
@@ -55,6 +55,9 @@ public:
 class DStyleOptionButton : public QStyleOptionButton, public DStyleOption
 {
 public:
+    explicit DStyleOptionButton();
+    DStyleOptionButton(const DStyleOptionButton &other);
+    DStyleOptionButton &operator=(const DStyleOptionButton &other);
     enum ButtonFeature {
         SuggestButton = (CommandLinkButton << 1),
         WarningButton = (SuggestButton << 1),

--- a/src/widgets/dstyleoption.cpp
+++ b/src/widgets/dstyleoption.cpp
@@ -102,6 +102,41 @@ void DStyleOption::init(const QWidget *widget)
   \a widget
   \sa Dtk::Widget::DSuggestButton
  */
+DStyleOptionButton::DStyleOptionButton()
+    : QStyleOptionButton ()
+    , DStyleOption ()
+{
+}
+
+/*!
+ * @brief DStyleOptionButton::DStyleOptionButton Custom copy constructor
+ * @param other Source object
+ */
+DStyleOptionButton::DStyleOptionButton(const DStyleOptionButton &other)
+    : QStyleOptionButton (other)
+    , DStyleOption (other)
+{
+    // `dciIcon` broke abi, so we need to distinguish weather `other` has dciIcon.
+    if (other.features & DStyleOptionButton::HasDciIcon)
+        dciIcon = other.dciIcon;
+}
+
+/*!
+ * @brief DStyleOptionButton::operator = Custom assignment constructor
+ * @param other Source obejct
+ * @return
+ */
+DStyleOptionButton &DStyleOptionButton::operator=(const DStyleOptionButton &other)
+{
+    // Set the value of the parent class member variable.
+    this->QStyleOptionButton::operator=(other);
+    this->DStyleOption::operator=(other);
+
+    if (other.features & DStyleOptionButton::HasDciIcon)
+        dciIcon = other.dciIcon;
+    return *this;
+}
+
 void DStyleOptionButton::init(const QWidget *widget)
 {
     DStyleOption::init(widget);


### PR DESCRIPTION
  This is a supplement for 9b6e60800597ecfb56135d208aa370f9d7285796
It's default assignment constructor will call buillt dtkwidget's  `dciIcon` conftructor, but `dciIcon` object is a unassignment space, it causes app crashed.
