### PR TITLE
chore: modify the result code of dprintpreviewdialog to accept or reject

### DIFF
--- a/src/widgets/dprintpreviewdialog.cpp
+++ b/src/widgets/dprintpreviewdialog.cpp
@@ -1042,7 +1042,7 @@ void DPrintPreviewDialogPrivate::initconnections()
 
     QObject::connect(advanceBtn, &QPushButton::clicked, q, [this] { this->showadvancesetting(); });
     QObject::connect(printDeviceCombo, SIGNAL(currentIndexChanged(int)), q, SLOT(_q_printerChanged(int)));
-    QObject::connect(cancelBtn, &DPushButton::clicked, q, &DPrintPreviewDialog::close);
+    QObject::connect(cancelBtn, &DPushButton::clicked, q, &DPrintPreviewDialog::reject);
     QObject::connect(pageRangeCombo, SIGNAL(currentIndexChanged(int)), q, SLOT(_q_pageRangeChanged(int)));
     QObject::connect(marginsCombo, SIGNAL(currentIndexChanged(int)), q, SLOT(_q_pageMarginChanged(int)));
     QObject::connect(printBtn, SIGNAL(clicked(bool)), q, SLOT(_q_startPrint(bool)));
@@ -2370,7 +2370,7 @@ void DPrintPreviewDialogPrivate::_q_startPrint(bool clicked)
 
     pview->print();
 
-    q->done(0);
+    q->accept();
 }
 
 void DPrintPreviewDialogPrivate::pageRangeError(TipsNum tipNum)


### PR DESCRIPTION
give the explicit result code (accept or reject) when pressing print button or cancel button of dprintpreviewdialog.

Log: modify the result code of dprintpreviewdialog to accept or reject
Influence: dprintpreviewdialog
Change-Id: Ic6ee36b7fc805ed16762bc203001d1248211fb1e