### PR TITLE
chore: DPrintPreviewDialog add update setting interface.

### DIFF
--- a/docs/widgets/dprintpreviewdialog.zh_CN.dox
+++ b/docs/widgets/dprintpreviewdialog.zh_CN.dox
@@ -1,0 +1,34 @@
+/*!
+@~chinese
+@file dprintpreviewdialog.h
+@ingroup dialog
+@class Dtk::Widget::DPrintPreviewDialog
+@brief Dtk 风格的打印预览页面.
+@details 一个用于创建 Dtk 风格的打印预览页面，通常情况下，只需要构建一个 DPrintPreivewDialog 对象，
+并将原始数据绘制到连接 `DPrintPreview::paintRequested` 信号的槽函数中,最后以模态的形式显示就可以正常使用。
+
+TODO: 添加类简介、示例代码、示例截图和函数使用说明等
+
+@fn DPrintPreviewSettingInfo *Dtk::Widget::DPrintPreviewDialog::createDialogSettingInfo(DPrintPreviewSettingInfo::SettingType type)
+@brief 根据打印类型 `type` 创建打印界面设置对象，包含当前界面设置信息。
+@details 若不支持 `type` 类型的设置，将返回 nullptr ；打印插件可能过滤部分类型的设置，同样返回 nullptr 。
+使用示例
+```c++
+DPrintPreviewDialog dialog;
+auto info = dialog.createDialogSettingInfo(DPrintPreviewSettingInfo::PS_Watermark);
+if (info) {
+    // 设置打印参数
+    ...
+    dialog.updateDialogSettingInfo(info);
+    delete info;
+}
+```
+@param[in] type 打印界面配置类型
+@return 打印设置对象指针
+@warning 创建的打印设置对象生命周期由调用方管理，需手动释放对象
+
+@fn void Dtk::Widget::DPrintPreviewDialog::updateDialogSettingInfo(DPrintPreviewSettingInfo *info)
+@brief 通过 `info` 配置信息更新打印界面配置，配置将更新界面控件，可调整的选项包括基础设置、打印方向、页面设置、水印等。
+@param[in] info 提供打印界面设置信息
+
+*/

--- a/include/widgets/dprintpreviewdialog.h
+++ b/include/widgets/dprintpreviewdialog.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -9,6 +9,7 @@
 #endif
 
 #include <DDialog>
+#include <dprintpreviewsettinginfo.h>
 #include <dprintpreviewwidget.h>
 
 DWIDGET_BEGIN_NAMESPACE
@@ -62,6 +63,9 @@ public:
 
     bool setAsynPreview(int totalPage);
     bool isAsynPreview() const;
+
+    DPrintPreviewSettingInfo *createDialogSettingInfo(DPrintPreviewSettingInfo::SettingType type);
+    void updateDialogSettingInfo(DPrintPreviewSettingInfo *info);
 
     // QWidget interface
 protected:

--- a/src/widgets/private/dprintpreviewdialog_p.h
+++ b/src/widgets/private/dprintpreviewdialog_p.h
@@ -203,7 +203,7 @@ class PreviewSettingsPluginHelper
 {
 public:
     PreviewSettingsPluginHelper(DPrintPreviewDialogPrivate *dd);
-    DPrintPreviewSettingInfo *loadInfo(DPrintPreviewSettingInfo::SettingType type);
+    DPrintPreviewSettingInfo *loadInfo(DPrintPreviewSettingInfo::SettingType type, bool manual = false);
 
     void setSubControlVisible(DPrintPreviewSettingInterface::SettingSubControl subControlType, bool visible);
     void setSubControlEnabled(DPrintPreviewSettingInterface::SettingSubControl subControlType, bool enabled);


### PR DESCRIPTION
Add interface updateDialogSettingInfo, apps can update print dialog
settings at construction time.
Add docs and UT, fix a bug that may cause a memory leak.

Log: DPrintPreviewDialog add update setting interface.
Influence: Add update setting interface.