### PR TITLE
fix: DAbstractDialog translucent background

### DIFF
--- a/src/widgets/dabstractdialog.cpp
+++ b/src/widgets/dabstractdialog.cpp
@@ -58,10 +58,9 @@ void DAbstractDialogPrivate::init(bool blurIfPossible)
         bgBlurWidget->setMaskColor(DBlurEffectWidget::AutoColor);
         bgBlurWidget->setMaskAlpha(204); // 80%
 
-        if (!DWindowManagerHelper::instance()->hasBlurWindow()
-                && DGuiApplicationHelper::instance()->isTabletEnvironment()) {
+        // blur if possible(wm support blur window)...
+        if (!DWindowManagerHelper::instance()->hasBlurWindow())
             blurIfPossible = false;
-        }
 
         bgBlurWidget->setBlurEnabled(blurIfPossible);
         q->setAttribute(Qt::WA_TranslucentBackground, blurIfPossible);


### PR DESCRIPTION
if windowmanager not support blur window effect
do not set `Qt::WA_TranslucentBackground` attribute setblurEnabled will not work

Issue: https://github.com/linuxdeepin/dtkwidget/issues/358
Log: fix Dialog translucent background