### PR TITLE
fix: Adjust SwitchButtonhandler's width in CompactMode

### DIFF
--- a/src/widgets/dstyle.cpp
+++ b/src/widgets/dstyle.cpp
@@ -1612,7 +1612,7 @@ int DStyle::pixelMetric(const QStyle *style, DStyle::PixelMetric m, const QStyle
         return 12;
     }
     case PM_SwitchButtonHandleWidth:
-        return 30;
+        return DSizeModeHelper::element(24, 30);
     case PM_SwithcButtonHandleHeight:
         return DSizeModeHelper::element(20, 24);
     case PM_FloatingWidgetRadius: {


### PR DESCRIPTION
  SwitchButtonhandlerWidth is different,
  It's SwitchButtonGroove's width is 40 in CompactMode, and 50 in NormalMode,
It's just by 5 / 3 * PM_SwitchButtonHandleWidth.

Issue: https://github.com/linuxdeepin/dtkwidget/issues/326