### PR TITLE
fix: Modify SearchEdit's icon

### DIFF
--- a/src/widgets/dsearchedit.cpp
+++ b/src/widgets/dsearchedit.cpp
@@ -287,10 +287,10 @@ void DSearchEditPrivate::init()
 
     action = new QAction(q);
     action->setObjectName("_d_search_leftAction");
-    action->setIcon(QIcon::fromTheme("search_action"));
+    action->setIcon(QIcon::fromTheme("search_indicator"));
     q->lineEdit()->addAction(action, QLineEdit::LeadingPosition);
     action->setVisible(false);
-    iconbtn->setIconSize(QSize(32, 32));
+    iconbtn->setIconSize(QSize(20, 20));
 
     DPalette pe;
     QStyleOption opt;
@@ -314,7 +314,7 @@ void DSearchEditPrivate::init()
     iconWidget->setAccessibleName("DSearchEditIconWidget");
     QHBoxLayout *center_layout = new QHBoxLayout(iconWidget);
     center_layout->setMargin(0);
-    center_layout->setSpacing(0);
+    center_layout->setSpacing(6);
 
     layout->setMargin(0);
     layout->setSpacing(0);

--- a/src/widgets/dstyle.cpp
+++ b/src/widgets/dstyle.cpp
@@ -2191,6 +2191,8 @@ int DStyle::pixelMetric(QStyle::PixelMetric m, const QStyleOption *opt, const QW
         return 16;
     case PM_MenuButtonIndicator:
         return DSizeModeHelper::element(8, QCommonStyle::pixelMetric(m, opt, widget));
+    case PM_LineEditIconSize:
+        return DSizeModeHelper::element(20, 20);
     default:
         break;
     }


### PR DESCRIPTION
  `search_indicator` and `search_action`'s size is 36 * 36, and
they have more than white space, now we update those icon in dtkgui and qt5integration, and remove unnecessary avoidance.

Issue: https://github.com/linuxdeepin/dtkwidget/issues/325
Log: It depends dtkgui and qt5integration.