### PR TITLE
fix: modify listview for compact mode

### DIFF
--- a/examples/collections/listviewexample.cpp
+++ b/examples/collections/listviewexample.cpp
@@ -98,7 +98,6 @@ DListViewExample::DListViewExample(QWidget *parent)
         lv->setModel(model);
         lv->setItemSpacing(space);
         lv->setSpacing(0);
-        lv->setIconSize(QSize(32, 32));
         lv->setFixedHeight(fixHeight);
         lv->setContentsMargins(0, 0, 0, 0);
     };
@@ -270,7 +269,6 @@ DGroupBoxExample::DGroupBoxExample(QWidget *parent)
     gbPicLabel->setPixmap(QPixmap(":/images/example/DGroupBox.png").scaled(568, 444, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
     contentComboBox->addItems({"自动"});
     contentComboBox->setMinimumWidth(213);
-    groupBoxWidget->setFixedHeight(48);
 
     contentLayout->setContentsMargins(10, 6, 10, 6);
     contentLayout->addWidget(contentTextLabel);

--- a/src/widgets/dstyle.cpp
+++ b/src/widgets/dstyle.cpp
@@ -2182,7 +2182,7 @@ int DStyle::pixelMetric(QStyle::PixelMetric m, const QStyleOption *opt, const QW
         return 16;
     case PM_ListViewIconSize:
     case PM_LargeIconSize:
-        return DSizeModeHelper::element(16, 24);
+        return 24;
     case PM_IconViewIconSize:
         return 32;
     case PM_ScrollView_ScrollBarOverlap:

--- a/src/widgets/dstyleditemdelegate.cpp
+++ b/src/widgets/dstyleditemdelegate.cpp
@@ -1247,7 +1247,8 @@ void DStyledItemDelegate::setBackgroundType(DStyledItemDelegate::BackgroundType 
         }
 
         int frame_margin = style->pixelMetric(static_cast<QStyle::PixelMetric>(DStyle::PM_FrameRadius));
-        d->margins += DSizeModeHelper::element(frame_margin / 2, frame_margin);
+        int left_right_margin = style->pixelMetric(static_cast<QStyle::PixelMetric>(DStyle::PM_ContentsMargins));
+        d->margins += QMargins(left_right_margin, frame_margin, left_right_margin, frame_margin);
     }
 }
 
@@ -1404,7 +1405,8 @@ bool DStyledItemDelegate::eventFilter(QObject *object, QEvent *event)
                 break;
 
             int frame_margin = DStyle::pixelMetric(view->style(), DStyle::PM_FrameRadius);
-            d->margins = QMargins() + DSizeModeHelper::element(frame_margin / 2, frame_margin);
+            int left_right_margin = DStyle::pixelMetric(view->style(), DStyle::PM_ContentsMargins);
+            d->margins = QMargins(left_right_margin, frame_margin, left_right_margin, frame_margin);
 
             // relayout to calculate size.
             view->doItemsLayout();


### PR DESCRIPTION
In compact mode:
modify margins to margin(10, 6, 10, 6)
modify icon size to QSize(24, 24)

Log: modify listview in compact mode
Issue: https://github.com/linuxdeepin/dtkwidget/issues/324
Influence: compact mode