### PR TITLE
fix: icon size is abnormal when dpi > 1

### DIFF
--- a/include/widgets/dstyle.h
+++ b/include/widgets/dstyle.h
@@ -347,6 +347,9 @@ public:
     inline QIcon standardIcon(DStyle::StandardPixmap standardIcon, const QStyleOption *opt, const QWidget *widget = nullptr) const
     { return m_dstyle ? m_dstyle->standardIcon(standardIcon, opt, widget) : DStyle::standardIcon(m_style, standardIcon, opt, widget); }
 
+    inline static qreal pixelRatioScaled(const qreal value, const QWidget *w = nullptr)
+    { return value * (w ? w->devicePixelRatioF() : qApp->devicePixelRatio()); }
+
 private:
     const QStyle *m_style;
     const DStyle *m_dstyle;

--- a/src/widgets/dstyle.cpp
+++ b/src/widgets/dstyle.cpp
@@ -2178,7 +2178,7 @@ int DStyle::pixelMetric(QStyle::PixelMetric m, const QStyleOption *opt, const QW
     case PM_SmallIconSize:
         return 14;
     case PM_ButtonIconSize:
-        return 16;
+        return int(DStyleHelper::pixelRatioScaled(16, widget));
     case PM_ListViewIconSize:
     case PM_LargeIconSize:
         return 24;

--- a/src/widgets/dstyle.cpp
+++ b/src/widgets/dstyle.cpp
@@ -1683,9 +1683,8 @@ QRect DStyle::subElementRect(const QStyle *style, DStyle::SubElement r, const QS
     }
     case SE_SwitchButtonHandle: {
         if (const DStyleOptionButton *btn = qstyleoption_cast<const DStyleOptionButton *>(opt)) {
-            DStyleHelper dstyle(style);
-            int handleWidth = dstyle.pixelMetric(PM_SwitchButtonHandleWidth, opt, widget);
-            int handleHeight = dstyle.pixelMetric(PM_SwithcButtonHandleHeight, opt, widget);
+            int handleWidth = btn->rect.width() / 2.0;
+            int handleHeight = btn->rect.height();
             //这里的borderWidth为2,间隙宽度为2, 所以为4
             QRect rectHandle(4, 4, handleWidth, handleHeight);
 


### PR DESCRIPTION
ButtonIconSize does't multiply ratio in dstyle, which lead to
both pixmap size and rect size disagree.

Log: modify ButtonIconSize's default value
Issue: https://github.com/linuxdeepin/dtkwidget/issues/390