### PR TITLE
fix: Build error for Qt 5.15~6.1

### DIFF
--- a/src/widgets/dstyle.cpp
+++ b/src/widgets/dstyle.cpp
@@ -2190,8 +2190,6 @@ int DStyle::pixelMetric(QStyle::PixelMetric m, const QStyleOption *opt, const QW
         return 16;
     case PM_MenuButtonIndicator:
         return DSizeModeHelper::element(8, QCommonStyle::pixelMetric(m, opt, widget));
-    case PM_LineEditIconSize:
-        return DSizeModeHelper::element(20, 20);
     default:
         break;
     }
@@ -2203,7 +2201,7 @@ int DStyle::pixelMetric(QStyle::PixelMetric m, const QStyleOption *opt, const QW
 #endif
 
     if (Q_UNLIKELY(LineEditIconSize == m)) {
-        return widget ? (widget->height() < 34 ? 16 : 32) : 24;
+        return DSizeModeHelper::element(20, 20);
     }
 
     if (Q_UNLIKELY(m < QStyle::PM_CustomBase)) {


### PR DESCRIPTION
  PM_LineEditIconSize is introduced in qt6.2 or patch,
the iconSize is always 20 in NormalMode or CompactMode. Building error is introduced in 'ec55b744d6ae766911d01948c56eac8b18fc5289'

Log: