### PR TITLE
fix: ListView's widget switching hide and show frequently

### DIFF
--- a/src/widgets/dstyleditemdelegate.cpp
+++ b/src/widgets/dstyleditemdelegate.cpp
@@ -1418,7 +1418,11 @@ bool DStyledItemDelegate::eventFilter(QObject *object, QEvent *event)
 
         if (event->type() == QEvent::Paint) {
             D_D(DStyledItemDelegate);
-            if (d->readyRecordVisibleWidgetOfCurrentFrame()) {
+            const QPaintEvent *pe = static_cast<QPaintEvent *>(event);
+            // We only hide widgets when updating all area, it maybe also to be paint when hover,
+            // and it's area is a specific part.
+            if (pe->rect() == view->viewport()->rect() &&
+                d->readyRecordVisibleWidgetOfCurrentFrame()) {
                 auto updateEvent = new QEvent(UpdateWidgetVisibleEvent);
                 qApp->postEvent(view->viewport(), updateEvent);
             }


### PR DESCRIPTION
  It's apperent when we set a widget for DStandardItem, and
hovering it, it look obvious when changing Widget's cursor.
  We hide widget depending on the different of last and current
frame, When we hover one item, Viewport also to be repaint, and it's area is an item hovered, this caused we made a calculation error.

Issue: https://github.com/linuxdeepin/dtkwidget/issues/364