### PR TITLE
Fix: Qt::ToolButtonTextUnderIcon does't work

### DIFF
--- a/src/widgets/dtoolbutton.cpp
+++ b/src/widgets/dtoolbutton.cpp
@@ -27,11 +27,6 @@ void DToolButton::paintEvent(QPaintEvent *event)
 void DToolButton::initStyleOption(QStyleOptionToolButton *option) const
 {
     QToolButton::initStyleOption(option);
-    //判断条件不用Qt::ToolButtonTextBesideIcon原因
-    //会强制居中，大小不受sizeHint（）控制
-    if (!option->icon.isNull() && !option->text.isEmpty()) {
-        option->toolButtonStyle = Qt::ToolButtonTextBesideIcon;
-    }
 }
 
 QSize DToolButton::sizeHint() const


### PR DESCRIPTION
set a fixed layout mode Qt::ToolButtonTextBesideIcon in codebase

Log: delete fixed layout Qt::ToolButtonTextBesideIcon
Issue: https://github.com/linuxdeepin/dtkwidget/issues/403