### PR TITLE
fix: Modify ButtonMargin from 10 to 8

### DIFF
--- a/src/widgets/dstyle.cpp
+++ b/src/widgets/dstyle.cpp
@@ -2141,7 +2141,7 @@ int DStyle::pixelMetric(QStyle::PixelMetric m, const QStyleOption *opt, const QW
     case PM_MenuDesktopFrameWidth:
         return 0;
     case PM_ButtonMargin:
-        return 10;
+        return 8;
     case PM_DefaultChildMargin:
         return DSizeModeHelper::element(pixelMetric(PM_FrameRadius, opt, widget), pixelMetric(PM_FrameRadius, opt, widget));
     case PM_DefaultFrameWidth:


### PR DESCRIPTION
  According to designer.
  It results display error for dde-control-center's shutcut keys
for `10`, so we change it back.

Issue: https://github.com/linuxdeepin/dtkwidget/pull/373