### PR TITLE
fix: DFloatingButton can't display dciicon

### DIFF
--- a/src/widgets/dfloatingbutton.cpp
+++ b/src/widgets/dfloatingbutton.cpp
@@ -67,7 +67,6 @@ DStyleOptionButton DFloatingButton::baseStyleOption() const
 void DFloatingButton::initStyleOption(DStyleOptionButton *option) const
 {
     DIconButton::initStyleOption(option);
-    option->features = QStyleOptionButton::ButtonFeature(DStyleOptionButton::FloatingButton);
 }
 
 DWIDGET_END_NAMESPACE

--- a/src/widgets/diconbutton.cpp
+++ b/src/widgets/diconbutton.cpp
@@ -282,7 +282,7 @@ void DIconButton::paintEvent(QPaintEvent *event)
     Q_UNUSED(event)
 
     DStylePainter p(this);
-    DStyleOptionButton opt;
+    DStyleOptionButton opt = baseStyleOption();
     initStyleOption(&opt);
     p.drawControl(DStyle::CE_IconButton, opt);
 }


### PR DESCRIPTION
  Option's `features` is overridden.