### PR TITLE
fix: suppress cmake warning for missing directory specified

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -21,7 +21,7 @@ sha512sums=('SKIP')
 
 build() {
   cd $sourcedir
-  cmake -GNinja \
+  cmake . -GNinja \
       -DMKSPECS_INSTALL_DIR=lib/qt/mkspecs/modules/\
       -DBUILD_PLUGINS=OFF \
       -DBUILD_DOCS=ON \


### PR DESCRIPTION
Fixes the following warning:

```
CMake Warning:
  No source or binary directory provided.  Both will be assumed to be the
  same as the current working directory, but note that this warning will
  become a fatal error in future CMake releases.
```