### PR TITLE
fix: 修复ArrowRectanble设置位置错误

### DIFF
--- a/src/widgets/darrowrectangle.cpp
+++ b/src/widgets/darrowrectangle.cpp
@@ -256,6 +256,13 @@ bool DArrowRectangle::event(QEvent *e)
 
 const QRect DArrowRectanglePrivate::currentScreenRect(const int x, const int y)
 {
+    if (floatMode == DArrowRectangle::FloatWidget) {
+        D_Q(DArrowRectangle);
+        if (q->parentWidget()) {
+            return q->parentWidget()->rect();
+        }
+    }
+
     for (QScreen *screen : qApp->screens())
         if (screen->geometry().contains(x, y)) {
             return screen->geometry();


### PR DESCRIPTION
当给ArrowRectanble设置parent的时候，调用show方法没有计算顶层窗口的位置导致最终计算的窗口错误

Log: 修复锁屏界面竖屏无法显示网络列表
Influence: 登陆界面和锁屏界面的网络列表
Bug: https://pms.uniontech.com/bug-view-195913.html