### PR TITLE
chore: bump version to 5.6.11

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+dtkwidget (5.6.11) unstable; urgency=medium
+
+  * Release 5.6.11
+  * FIX dtk#51 dtk#62 dtk#36
+  * FIX bug-195913 DArrowRectangle postion calc error
+
+ -- Deepin Packages Builder <packages@deepin.com>  Mon, 08 May 2023 13:35:05 +0800
+
 dtkwidget (5.6.10) unstable; urgency=medium
 
   * Release 5.6.10


### PR DESCRIPTION
update changelog