### PR TITLE
fix: 修改分屏菜单位置错误

### DIFF
--- a/src/widgets/darrowrectangle.cpp
+++ b/src/widgets/darrowrectangle.cpp
@@ -258,7 +258,7 @@ const QRect DArrowRectanglePrivate::currentScreenRect(const int x, const int y)
 {
     if (floatMode == DArrowRectangle::FloatWidget) {
         D_Q(DArrowRectangle);
-        if (q->parentWidget()) {
+        if (q->windowType() == Qt::Widget && q->parentWidget()) {
             return q->parentWidget()->rect();
         }
     }


### PR DESCRIPTION
只Qt::Widget的窗口并有父窗口的计算使用父窗口rect

Log: 修改分屏菜单位置错误
Bug: https://pms.uniontech.com/bug-view-199083.html
Influence: 锁屏界面/任务栏等网络插件窗口显示,窗口分屏提示窗口