### PR TITLE
chore: ignore doxygen-theme folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ dtkwidget.pc
 *.qdoc
 CMakeLists.txt.user
 
+
 # Ignore Doxygen theme files
 docs/doxygen-theme/
 


### PR DESCRIPTION
add new rules to .gitignore

Log: 对.gitignore文件添加忽略文件规则，避免dtk文档主题编译产物污染git目录

Issue: linuxdeepin/dtk #99