### PR TITLE
chore: deprecate dhidpihelper

### DIFF
--- a/include/util/dhidpihelper.h
+++ b/include/util/dhidpihelper.h
@@ -9,10 +9,10 @@
 
 DWIDGET_BEGIN_NAMESPACE
 
-class DHiDPIHelper
+class Q_DECL_DEPRECATED DHiDPIHelper
 {
 public:
-    static QPixmap loadNxPixmap(const QString &fileName);
+    Q_DECL_DEPRECATED_X("Use Dtk::Gui::DIcon::loadNxPixmap") static QPixmap loadNxPixmap(const QString &fileName);
 };
 
 DWIDGET_END_NAMESPACE

--- a/src/util/dhidpihelper.cpp
+++ b/src/util/dhidpihelper.cpp
@@ -4,10 +4,7 @@
 
 #include "dhidpihelper.h"
 
-#include <QPixmap>
-#include <QImageReader>
-#include <QApplication>
-#include <QIcon>
+#include <DIcon>
 
 DWIDGET_BEGIN_NAMESPACE
 
@@ -24,23 +21,7 @@ DWIDGET_BEGIN_NAMESPACE
  */
 QPixmap DHiDPIHelper::loadNxPixmap(const QString &fileName)
 {
-    qreal sourceDevicePixelRatio = 1.0;
-    qreal devicePixelRatio = qApp->devicePixelRatio();
-    QPixmap pixmap;
-
-    if (!qFuzzyCompare(sourceDevicePixelRatio, devicePixelRatio)) {
-        QImageReader reader;
-        reader.setFileName(qt_findAtNxFile(fileName, devicePixelRatio, &sourceDevicePixelRatio));
-        if (reader.canRead()) {
-            reader.setScaledSize(reader.size() * (devicePixelRatio / sourceDevicePixelRatio));
-            pixmap = QPixmap::fromImage(reader.read());
-            pixmap.setDevicePixelRatio(devicePixelRatio);
-        }
-    } else {
-        pixmap.load(fileName);
-    }
-
-    return pixmap;
+    return DTK_GUI_NAMESPACE::DIcon::loadNxPixmap(fileName);
 }
 
 DWIDGET_END_NAMESPACE

--- a/src/widgets/dsimplelistview.cpp
+++ b/src/widgets/dsimplelistview.cpp
@@ -4,6 +4,7 @@
 
 #include "dsimplelistview.h"
 #include <DObjectPrivate>
+#include <DIcon>
 #include <QApplication>
 #include <QDebug>
 #include <QEvent>
@@ -14,9 +15,8 @@
 #include <QPointer>
 #include <QPainterPath>
 
-#include "dhidpihelper.h"
-
 DCORE_USE_NAMESPACE
+DGUI_USE_NAMESPACE
 DWIDGET_BEGIN_NAMESPACE
 
 class DSimpleListViewPrivate : public DTK_CORE_NAMESPACE::DObjectPrivate
@@ -107,19 +107,19 @@ DSimpleListView::DSimpleListView(QWidget *parent) : QWidget(parent), DObject(*ne
     d->titleHoverColumn = -1;
     d->titlePressColumn = -1;
 
-    arrowUpDarkNormalImage = DHiDPIHelper::loadNxPixmap(":/images/dark/images/arrow_up_normal.svg");
-    arrowUpDarkHoverImage = DHiDPIHelper::loadNxPixmap(":/images/dark/images/arrow_up_hover.svg");
-    arrowUpDarkPressImage = DHiDPIHelper::loadNxPixmap(":/images/dark/images/arrow_up_press.svg");
-    arrowDownDarkNormalImage = DHiDPIHelper::loadNxPixmap(":/images/dark/images/arrow_down_normal.svg");
-    arrowDownDarkHoverImage = DHiDPIHelper::loadNxPixmap(":/images/dark/images/arrow_down_hover.svg");
-    arrowDownDarkPressImage = DHiDPIHelper::loadNxPixmap(":/images/dark/images/arrow_down_press.svg");
+    arrowUpDarkNormalImage = DIcon::loadNxPixmap(":/images/dark/images/arrow_up_normal.svg");
+    arrowUpDarkHoverImage = DIcon::loadNxPixmap(":/images/dark/images/arrow_up_hover.svg");
+    arrowUpDarkPressImage = DIcon::loadNxPixmap(":/images/dark/images/arrow_up_press.svg");
+    arrowDownDarkNormalImage = DIcon::loadNxPixmap(":/images/dark/images/arrow_down_normal.svg");
+    arrowDownDarkHoverImage = DIcon::loadNxPixmap(":/images/dark/images/arrow_down_hover.svg");
+    arrowDownDarkPressImage = DIcon::loadNxPixmap(":/images/dark/images/arrow_down_press.svg");
 
-    arrowUpLightNormalImage = DHiDPIHelper::loadNxPixmap(":/images/light/images/arrow_up_normal.svg");
-    arrowUpLightHoverImage = DHiDPIHelper::loadNxPixmap(":/images/light/images/arrow_up_hover.svg");
-    arrowUpLightPressImage = DHiDPIHelper::loadNxPixmap(":/images/light/images/arrow_up_press.svg");
-    arrowDownLightNormalImage = DHiDPIHelper::loadNxPixmap(":/images/light/images/arrow_down_normal.svg");
-    arrowDownLightHoverImage = DHiDPIHelper::loadNxPixmap(":/images/light/images/arrow_down_hover.svg");
-    arrowDownLightPressImage = DHiDPIHelper::loadNxPixmap(":/images/light/images/arrow_down_press.svg");
+    arrowUpLightNormalImage = DIcon::loadNxPixmap(":/images/light/images/arrow_up_normal.svg");
+    arrowUpLightHoverImage = DIcon::loadNxPixmap(":/images/light/images/arrow_up_hover.svg");
+    arrowUpLightPressImage = DIcon::loadNxPixmap(":/images/light/images/arrow_up_press.svg");
+    arrowDownLightNormalImage = DIcon::loadNxPixmap(":/images/light/images/arrow_down_normal.svg");
+    arrowDownLightHoverImage = DIcon::loadNxPixmap(":/images/light/images/arrow_down_hover.svg");
+    arrowDownLightPressImage = DIcon::loadNxPixmap(":/images/light/images/arrow_down_press.svg");
 
     arrowUpNormalImage = arrowUpLightNormalImage;
     arrowUpHoverImage = arrowUpLightHoverImage;

--- a/src/widgets/dtoast.cpp
+++ b/src/widgets/dtoast.cpp
@@ -7,16 +7,15 @@
 #if DTK_VERSION < DTK_VERSION_CHECK(6, 0, 0, 0)
 
 #include <DObjectPrivate>
+#include <DIcon>
 
 #include <QGraphicsOpacityEffect>
 #include <QPropertyAnimation>
 #include <QHBoxLayout>
 #include <QLabel>
-#include <QIcon>
 
 #include "dthememanager.h"
 #include "dgraphicsgloweffect.h"
-#include "dhidpihelper.h"
 
 DWIDGET_BEGIN_NAMESPACE
 
@@ -117,7 +116,7 @@ void DToast::setIcon(QString iconfile)
     D_D(DToast);
     d->icon = QIcon(iconfile);
     d->iconLabel->setVisible(true);
-    d->iconLabel->setPixmap(DHiDPIHelper::loadNxPixmap(iconfile));
+    d->iconLabel->setPixmap(DTK_GUI_NAMESPACE::DIcon::loadNxPixmap(iconfile));
 }
 
 /*!


### PR DESCRIPTION
DHiDPIHelper has nothing to do with dtkwidget. Move the only function loadNxPixmap to Dtk::Gui::DIcon. Deprecate the implementation in dtkwidget.

Log: deprecate dhidpihelper