### PR TITLE
fix: update dependency libfreetype-dev

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Build-Depends: debhelper-compat (= 12), pkg-config, libudev-dev,
  libqt5x11extras5-dev, libxext-dev, qttools5-dev-tools, qttools5-dev,
  x11proto-xext-dev, libxcb-util0-dev, libstartup-notification0-dev,
  libmtdev-dev, qtbase5-private-dev, libegl1-mesa-dev, libudev-dev,
- libfontconfig1-dev, libfreetype6-dev, libglib2.0-dev, libxrender-dev,
+ libfontconfig1-dev, libfreetype-dev, libglib2.0-dev, libxrender-dev,
  libdtkcore-dev, libgsettings-qt-dev, libqt5svg5-dev, libxi-dev,
  libdtkgui-dev, libcups2-dev, libgtest-dev, libdtkcore5-bin, cmake, doxygen
 Standards-Version: 3.9.8


### PR DESCRIPTION
libfreetype6-dev is a transitional package. Debian sid now uses libfreetype-dev. Change libfreetype6-dev to libfreetype-dev.

Log: update dependency libfreetype-dev