### PR TITLE
chore: do not show alert message if text is empty 

### DIFF
--- a/src/widgets/dalertcontrol.cpp
+++ b/src/widgets/dalertcontrol.cpp
@@ -207,6 +207,9 @@ void DAlertControl::showAlertMessage(const QString &text, QWidget *follower, int
     if (!d->target)
         return;
 
+    if (text.isEmpty())
+        return;
+
     if (!d->tooltip) {
         d->tooltip = new DToolTip(text);
         d->tooltip->setObjectName("AlertTooltip");


### PR DESCRIPTION
show an empty alert frame makes no sense