### PR TITLE
fix: 修复打印预览，切换打印机的时候预览图颜色显示异常

### DIFF
--- a/src/widgets/dprintpreviewdialog.cpp
+++ b/src/widgets/dprintpreviewdialog.cpp
@@ -1664,6 +1664,9 @@ void DPrintPreviewDialogPrivate::_q_printerChanged(int index)
     paperSizeCombo->clear();
     paperSizeCombo->blockSignals(true);
     QString currentName = printDeviceCombo->itemText(index);
+    colorModeCombo->blockSignals(true);
+    colorModeCombo->clear();
+    colorModeCombo->blockSignals(false);
     if (isActualPrinter(currentName)) {
         //actual printer
         if (printer) {
@@ -1682,10 +1685,6 @@ void DPrintPreviewDialogPrivate::_q_printerChanged(int index)
         //判断当前打印机是否支持彩色打印，不支持彩色打印删除彩色打印选择选项，pdf不做判断
         QPlatformPrinterSupport *ps = QPlatformPrinterSupportPlugin::get();
         QPrintDevice currentDevice = ps->createPrintDevice(printDeviceCombo->currentText());
-        // Keep previous selection.
-        const int selectColorIndex = 0;
-        bool previousPrinterSelectColor = (supportedColorMode && (selectColorIndex == colorModeCombo->currentIndex()));
-        colorModeCombo->clear();
         supportedColorMode = false;
         if (currentDevice.supportedColorModes().contains(QPrint::Color)) {
             if (!isInited) {
@@ -1696,6 +1695,8 @@ void DPrintPreviewDialogPrivate::_q_printerChanged(int index)
             }
             colorModeCombo->blockSignals(true);
             colorModeCombo->addItem(qApp->translate("DPrintPreviewDialogPrivate", "Color"));
+            // Ensure that the signal CurrentIndexChanged is triggered afterwards
+            colorModeCombo->setCurrentIndex(-1);
             colorModeCombo->blockSignals(false);
             updateSubControlSettings(DPrintPreviewSettingInfo::PS_ColorMode);
             supportedColorMode = true;
@@ -1703,6 +1704,8 @@ void DPrintPreviewDialogPrivate::_q_printerChanged(int index)
         if (currentDevice.supportedColorModes().contains(QPrint::GrayScale)) {
             colorModeCombo->blockSignals(true);
             colorModeCombo->addItem(qApp->translate("DPrintPreviewDialogPrivate", "Grayscale"));
+            // Ensure that the signal CurrentIndexChanged is triggered afterwards
+            colorModeCombo->setCurrentIndex(-1);
             colorModeCombo->blockSignals(false);
             updateSubControlSettings(DPrintPreviewSettingInfo::PS_ColorMode);
             waterColor = QColor("#6f6f6f");
@@ -1713,12 +1716,6 @@ void DPrintPreviewDialogPrivate::_q_printerChanged(int index)
         if (supportedColorMode) {
             colorModeCombo->setCurrentText(qApp->translate("DPrintPreviewDialogPrivate", "Color"));
             settingHelper->setSubControlEnabled(DPrintPreviewSettingInterface::SC_Watermark_TextColor, true);
-
-            // Refresh the current print ColorMode, clear() and blockSignals() cause
-            // the current ColorMode to be inconsistent with currentIndex().
-            if (previousPrinterSelectColor) {
-                _q_ColorModeChange(selectColorIndex);
-            }
         } else {
             colorModeCombo->setCurrentText(qApp->translate("DPrintPreviewDialogPrivate", "Grayscale"));
             settingHelper->setSubControlEnabled(DPrintPreviewSettingInterface::SC_Watermark_TextColor, false);
@@ -1731,8 +1728,11 @@ void DPrintPreviewDialogPrivate::_q_printerChanged(int index)
         duplexCombo->clear();
         settingHelper->setSubControlEnabled(DPrintPreviewSettingInterface::SC_DuplexWidget, false);
         settingHelper->setSubControlEnabled(DPrintPreviewSettingInterface::SC_Watermark_TextColor, true);
-        if (colorModeCombo->count() == 1)
-            colorModeCombo->insertItem(0, qApp->translate("DPrintPreviewDialogPrivate", "Color"));
+        colorModeCombo->blockSignals(true);
+        colorModeCombo->addItem(qApp->translate("DPrintPreviewDialogPrivate", "Color"));
+        colorModeCombo->addItem(qApp->translate("DPrintPreviewDialogPrivate", "Grayscale"));
+        // Ensure that the signal CurrentIndexChanged is triggered afterwards
+        colorModeCombo->setCurrentIndex(-1);
         updateSubControlSettings(DPrintPreviewSettingInfo::PS_ColorMode);
         colorModeCombo->blockSignals(false);
         colorModeCombo->setCurrentIndex(0);


### PR DESCRIPTION
颜色选项默认选择第一项，第一项有可能是彩色或黑白，QCombobox在设置与之前相同的项的时候其CurrentIndexChanged信号不会被触发，正因如此，导致预览图没有及时没刷新，修改为在为组合框添加item的时候，将其currentIndex设置为-1，保证后续的CurrentIndexChanged信号及时被触发

Log: 修复打印预览，切换打印机的时候预览图颜色显示异常
Bug: https://pms.uniontech.com/bug-view-220315.html
Influence: 打印预览切换打印机时预览图的颜色表现