### PR TITLE
fix: DApplication初始化过程中会覆盖原有事件掩码，导致丢失事件

### DIFF
--- a/src/widgets/private/startupnotifications/startupnotificationmonitor.cpp
+++ b/src/widgets/private/startupnotifications/startupnotificationmonitor.cpp
@@ -77,11 +77,22 @@ StartupNotificationMonitor::StartupNotificationMonitor() :
         return;
 
     int screen = 0;
-
     xcb_screen_t *s = xcb_aux_get_screen (QX11Info::connection(), screen);
-    const uint32_t select_input_val[] = { XCB_EVENT_MASK_PROPERTY_CHANGE };
-    xcb_change_window_attributes (QX11Info::connection(), s->root, XCB_CW_EVENT_MASK,
-                                  select_input_val);
+    xcb_get_window_attributes_cookie_t attr_cookie = xcb_get_window_attributes (QX11Info::connection(), s->root);
+    xcb_get_window_attributes_reply_t *attr_reply = xcb_get_window_attributes_reply (QX11Info::connection(), attr_cookie, NULL);
+
+    if (attr_reply) {
+        uint32_t old_event_mask = attr_reply->your_event_mask;
+        if (!(old_event_mask & XCB_EVENT_MASK_PROPERTY_CHANGE)) {
+            const uint32_t select_input_val[] = { XCB_EVENT_MASK_PROPERTY_CHANGE | old_event_mask };
+
+            xcb_change_window_attributes (QX11Info::connection(), s->root, XCB_CW_EVENT_MASK,
+                                          select_input_val);
+        }
+        free(attr_reply);
+    } else {
+        qWarning() << "can not get xcb window attributes reply";
+    }
 
     display = sn_xcb_display_new (QX11Info::connection(), NULL, NULL);
 


### PR DESCRIPTION
Log:DApplication应用初始化时通过设置xcb窗口属性，设置了XCB_EVENT_MASK_PROPERTY_CHANGE事件掩码，此时Xorg会对发送给客户端的事件根据事件掩码来过滤，例如关闭文件选择对话框时发送的类型为focusIn的clientMessageEvent就不会发送给客户端。虽然在关闭对话框时，XOrg也会发送一次FocusIn底层事件，但这个事件和窗口的关闭信号有时序上的问题，所以真正重要的是前面所说的clientMessageEvent。故添加事件掩码以获取对应事件。

Bug: https://pms.uniontech.com/bug-view-220369.html