### PR TITLE
fix(DFileChooserEdit): file chooser is opened when Enter pressed

### DIFF
--- a/src/widgets/dfilechooseredit.cpp
+++ b/src/widgets/dfilechooseredit.cpp
@@ -251,6 +251,7 @@ void DFileChooserEditPrivate::init()
         btn->setFixedWidth(defaultButtonWidth());
         btn->setIconSize(defaultIconSize());
     });
+    btn->setAutoDefault(false);
 
     q->setDialogDisplayPosition(DFileChooserEdit::DialogDisplayPosition::CurrentMonitorCenter);
 


### PR DESCRIPTION
Issues: linuxdeepin/developer-center#7089