### PR TITLE
fix: black circle in PasswordEdit

### DIFF
--- a/src/widgets/dlineedit.cpp
+++ b/src/widgets/dlineedit.cpp
@@ -341,6 +341,7 @@ void DLineEdit::setEchoMode(QLineEdit::EchoMode mode)
 {
     D_D(DLineEdit);
     d->lineEdit->setEchoMode(mode);
+    d->updateFont();
 }
 
 /*!
@@ -667,6 +668,8 @@ bool DLineEdit::eventFilter(QObject *watched, QEvent *event)
         event->accept();
         pLineEdit->setFocus();
         return true;
+    } else if (event->type() == QEvent::FontChange) {
+        d->updateFont();
     }
 
 //    if (d->frame)
@@ -702,7 +705,20 @@ DLineEditPrivate::DLineEditPrivate(DLineEdit *q)
 
 void DLineEditPrivate::updateTooltipPos()
 {
-    //control->updateTooltipPos();
+}
+
+void DLineEditPrivate::updateFont()
+{
+    Q_Q(DLineEdit);
+    
+    if (lineEdit->echoMode() == QLineEdit::Password) {
+        QFont passwordFont = lineEdit->font();
+        passwordFont.setPixelSize(6);
+        passwordFont.setLetterSpacing(passwordFont.letterSpacingType(), 200);
+        lineEdit->setFont(passwordFont);
+    } else {
+        lineEdit->setFont(q->font());
+    }
 }
 
 void DLineEditPrivate::init()
@@ -732,6 +748,8 @@ void DLineEditPrivate::init()
     q->connect(lineEdit, &QLineEdit::returnPressed, q, &DLineEdit::returnPressed);
     q->connect(lineEdit, &QLineEdit::editingFinished, q, &DLineEdit::editingFinished);
     q->connect(lineEdit, &QLineEdit::selectionChanged, q, &DLineEdit::selectionChanged);
+
+    updateFont();
 }
 
 DWIDGET_END_NAMESPACE

--- a/src/widgets/dpasswordedit.cpp
+++ b/src/widgets/dpasswordedit.cpp
@@ -127,7 +127,7 @@ void DPasswordEditPrivate::init()
 {
     D_Q(DPasswordEdit);
 
-    q->lineEdit()->setEchoMode(QLineEdit::Password);
+    q->DLineEdit::setEchoMode(QLineEdit::Password);
     q->lineEdit()->setAttribute(Qt::WA_InputMethodEnabled, false);
 
     QList<QWidget *> list;

--- a/src/widgets/private/dlineedit_p.h
+++ b/src/widgets/private/dlineedit_p.h
@@ -23,6 +23,7 @@ class DLineEditPrivate : public DTK_CORE_NAMESPACE::DObjectPrivate
 public:
     DLineEditPrivate(DLineEdit *q);
     void updateTooltipPos();
+    void updateFont();
 
     void init();
 


### PR DESCRIPTION
set the size of black circle to 6 pixel by changing the font,
set the letter spacing to 200 under PercentageSpacing type.

Issue: https://github.com/linuxdeepin/developer-center/issues/7335