### PR TITLE
chore: disable broken workflow build

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -16,13 +16,6 @@ test_build:
               - x86_64
               - aarch64
 
-          - name: debian
-            paths:
-              - target_project: deepin:CI
-                target_repository: debian_sid
-            architectures:
-              - x86_64
-
           - name: archlinux
             paths:
               - target_project: deepin:CI


### PR DESCRIPTION
Disable debian build cause dtkwidget may depends on qt6.6, but debian's version is 6.4.

Log: disable broken workflow build