### PR TITLE
Revert "fix: 自定义页码切换问题"

### DIFF
--- a/src/widgets/dprintpreviewdialog.cpp
+++ b/src/widgets/dprintpreviewdialog.cpp
@@ -1213,7 +1213,7 @@ void DPrintPreviewDialogPrivate::initconnections()
             this->marginsUpdate(false);
         }
         if (pview->pageRangeMode() == DPrintPreviewWidget::SelectPage && pageRangeCombo->isEnabled())
-            pageRangeCombo->setCurrentIndex(PAGERANGE_ALL);
+            _q_customPagesFinished();
 
     });
 
@@ -1769,7 +1769,7 @@ void DPrintPreviewDialogPrivate::_q_printerChanged(int index)
 
     marginsUpdate(true);
     if (pview->pageRangeMode() == DPrintPreviewWidget::SelectPage && pageRangeCombo->isEnabled())
-        pageRangeCombo->setCurrentIndex(PAGERANGE_ALL);
+        _q_customPagesFinished();
     paperSizeCombo->blockSignals(false);
     if (isInited)
         updateAllControlSettings();
@@ -1859,7 +1859,7 @@ void DPrintPreviewDialogPrivate::_q_pageMarginChanged(int index)
     }
 
     if (pview->pageRangeMode() == DPrintPreviewWidget::SelectPage && pageRangeCombo->isEnabled())
-        pageRangeCombo->setCurrentIndex(PAGERANGE_ALL);
+        _q_customPagesFinished();
 
     if (marginOldValue.length() > 4)
         marginOldValue.clear();
@@ -1912,7 +1912,7 @@ void DPrintPreviewDialogPrivate::_q_orientationChanged(int index)
         pview->setOrientation(DPrinter::Landscape);
     }
     if (pview->pageRangeMode() == DPrintPreviewWidget::SelectPage && pageRangeCombo->isEnabled())
-        pageRangeCombo->setCurrentIndex(PAGERANGE_ALL);
+        _q_customPagesFinished();
 }
 
 /*!
@@ -2008,7 +2008,7 @@ void DPrintPreviewDialogPrivate::adjustMargins()
     this->printer->setPageMargins(QMarginsF(leftMarginF, topMarginF, rightMarginF, bottomMarginF), QPageLayout::Millimeter);
     this->pview->updatePreview();
     if (pview->pageRangeMode() == DPrintPreviewWidget::SelectPage && pageRangeCombo->isEnabled())
-        pageRangeCombo->setCurrentIndex(PAGERANGE_ALL);
+        _q_customPagesFinished();
 }
 
 /*!


### PR DESCRIPTION
Do not reset custom page ranges when changing printers/page size/Anything like this.

Issue: https://github.com/linuxdeepin/developer-center/issues/7983
Log: revert f53dfffb63cfcd3f005019fcc2057c652c20822b