### PR TITLE
fix: 解决wayland下，DDialog窗口透明问题的问题

### DIFF
--- a/src/widgets/dabstractdialog.cpp
+++ b/src/widgets/dabstractdialog.cpp
@@ -68,6 +68,11 @@ void DAbstractDialogPrivate::init(bool blurIfPossible)
         q->setAttribute(Qt::WA_TranslucentBackground, blurIfPossible);
     } else if (noTitlebarEnabled()) {
         handle = new DPlatformWindowHandle(q, q);
+
+        if (!handle->enableBlurWindow()) {
+            handle->setEnableBlurWindow(true);
+        }
+
         // fix wayland no titlebar
         //q->setWindowFlags(q->windowFlags() | Qt::FramelessWindowHint);
     }


### PR DESCRIPTION
wayland下，当进程设置DGuiApplicationHelper::ColorCompositing后，DDialog需要 主动设置模糊窗口效果

Log:
Bug: https://pms.uniontech.com/bug-view-249975.html Influence: wayland下，DDialog窗口模糊