### PR TITLE
fix: DMessageManager::sendMessage cause crash

### DIFF
--- a/src/widgets/dmessagemanager.cpp
+++ b/src/widgets/dmessagemanager.cpp
@@ -68,17 +68,21 @@ template<typename IconType>
 static void sendMessage_helper(DMessageManager *manager, QWidget *par, IconType icon, const QString &message)
 {
     QWidget *content = par->findChild<QWidget *>(D_MESSAGE_MANAGER_CONTENT, Qt::FindDirectChildrenOnly);
-    int text_message_count = 0;
 
-    for (DFloatingMessage *message : content->findChildren<DFloatingMessage*>(QString(), Qt::FindDirectChildrenOnly)) {
-        if (message->messageType() == DFloatingMessage::TransientType) {
-            ++text_message_count;
+    if (content) {
+        int text_message_count = 0;
+
+        for (DFloatingMessage *message : content->findChildren<DFloatingMessage *>(QString(), Qt::FindDirectChildrenOnly)) {
+            if (message->messageType() == DFloatingMessage::TransientType) {
+                ++text_message_count;
+            }
+        }
+
+        // TransientType 类型的通知消息，最多只允许同时显示三个
+        if (text_message_count >= 3) {
+            return;
         }
     }
-
-    // TransientType 类型的通知消息，最多只允许同时显示三个
-    if (text_message_count >= 3)
-        return;
 
     DFloatingMessage *floMsg = new DFloatingMessage(DFloatingMessage::TransientType);
     floMsg->setAttribute(Qt::WA_DeleteOnClose);


### PR DESCRIPTION
when compiled with Qt6, in sendMessage_helper, seems that content could be nullptr when QWebEngineView is DMainWindow's centralWidget

Log: add judgment whether content is nullptr in sendMessage_helper