### PR TITLE
fix: DTitleBar动态设置Icon时间距异常

### DIFF
--- a/src/widgets/dtitlebar.cpp
+++ b/src/widgets/dtitlebar.cpp
@@ -775,6 +775,9 @@ void DTitlebarPrivate::setIconVisible(bool visible)
         return;
 
     if (visible) {
+        if (auto spacerItem = dynamic_cast<QSpacerItem *>(leftLayout->takeAt(0)))
+            delete leftLayout->takeAt(0);
+            
         leftLayout->insertSpacing(0, 10);
         leftLayout->insertWidget(1, iconLabel, 0, Qt::AlignLeading | Qt::AlignVCenter);
         iconLabel->show();


### PR DESCRIPTION
spacerItem多次设置,改为设置前先移除之前的

Log: