### PR TITLE
fix: 控制中心标题栏返回按钮消失

### DIFF
--- a/src/widgets/dtitlebar.cpp
+++ b/src/widgets/dtitlebar.cpp
@@ -775,7 +775,7 @@ void DTitlebarPrivate::setIconVisible(bool visible)
         return;
 
     if (visible) {
-        if (auto spacerItem = dynamic_cast<QSpacerItem *>(leftLayout->takeAt(0)))
+        if (dynamic_cast<QSpacerItem *>(leftLayout->itemAt(0)))
             delete leftLayout->takeAt(0);
             
         leftLayout->insertSpacing(0, 10);


### PR DESCRIPTION
DTK清除多余space使用的方法有问题,应使用itemAt而不是takeAt

Log: 控制中心标题栏返回按钮消失
Bug: https://pms.uniontech.com/bug-view-264379.html
Influence: 控制中心-标题栏