### PR TITLE
fix: 如果窗口打开时即为最大化状态,则最大化图标显示错误

### DIFF
--- a/src/widgets/dtitlebar.cpp
+++ b/src/widgets/dtitlebar.cpp
@@ -1104,7 +1104,7 @@ bool DTitlebar::eventFilter(QObject *obj, QEvent *event)
         switch (event->type()) {
         case QEvent::ShowToParent:
             d->handleParentWindowIdChange();
-            d->updateButtonsState(d->targetWindow()->windowFlags());
+            d->handleParentWindowStateChange();
             break;
         case QEvent::Resize:
             if (d->autoHideOnFullscreen) {


### PR DESCRIPTION
窗口打开时没有windowstatechanged事件,不会去设置窗口状态,在showEvent中处理一下

Log:
Bug: https://pms.uniontech.com/bug-view-262201.html Influence: mainwindow最大化