### PR TITLE
chore: use testAttribute instead of environment test

### DIFF
--- a/src/widgets/dmainwindow.cpp
+++ b/src/widgets/dmainwindow.cpp
@@ -43,7 +43,7 @@ DMainWindowPrivate::DMainWindowPrivate(DMainWindow *qq)
     titlebar = new DTitlebar(qq);
     titlebar->setAccessibleName("DMainWindowTitlebar");
     auto noTitlebarEnabled = []{
-        if (qEnvironmentVariable("DDE_CURRENT_COMPOSITOR") == "TreeLand") {
+        if (DGuiApplicationHelper::testAttribute(DGuiApplicationHelper::IsWaylandPlatform)) {
             return true;
         }
         QFunctionPointer enableNoTitlebar = qApp->platformFunction("_d_isEnableNoTitlebar");

--- a/src/widgets/dtitlebar.cpp
+++ b/src/widgets/dtitlebar.cpp
@@ -354,7 +354,7 @@ void DTitlebarPrivate::init()
     q->setFocusPolicy(Qt::StrongFocus);
 
     auto noTitlebarEnabled = []{
-        if (qEnvironmentVariable("DDE_CURRENT_COMPOSITOR") == "TreeLand") {
+        if (DGuiApplicationHelper::testAttribute(DGuiApplicationHelper::IsWaylandPlatform)) {
             return true;
         }
 
@@ -431,7 +431,8 @@ void DTitlebarPrivate::updateFullscreen()
 void DTitlebarPrivate::updateButtonsState(Qt::WindowFlags type)
 {
     D_Q(DTitlebar);
-    bool useDXcb = DPlatformWindowHandle::isEnabledDXcb(targetWindow()) || qEnvironmentVariable("DDE_CURRENT_COMPOSITOR") == "TreeLand";
+    bool useDXcb = DPlatformWindowHandle::isEnabledDXcb(targetWindow()) ||
+                   DGuiApplicationHelper::testAttribute(DGuiApplicationHelper::IsWaylandPlatform);
     bool isFullscreen = targetWindow()->windowState().testFlag(Qt::WindowFullScreen);
 
 //    bool forceShow = !useDXcb;


### PR DESCRIPTION
DGuiApplicationHelper::testAttribute(DGuiApplicationHelper::IsWaylandPlatform)

https://github.com/linuxdeepin/dtkgui/pull/266