### PR TITLE
fix: exit animation of the application disappeared in treeland

### DIFF
--- a/src/widgets/dtitlebar.cpp
+++ b/src/widgets/dtitlebar.cpp
@@ -1533,7 +1533,7 @@ void DTitlebar::setVisible(bool visible)
         connect(d->maxButton, SIGNAL(clicked()), this, SLOT(_q_toggleWindowState()), Qt::UniqueConnection);
         connect(this, SIGNAL(doubleClicked()), this, SLOT(_q_toggleWindowState()), Qt::UniqueConnection);
         connect(d->minButton, SIGNAL(clicked()), this, SLOT(_q_showMinimized()), Qt::UniqueConnection);
-        connect(d->closeButton, &DWindowCloseButton::clicked, d->targetWindow(), &QWidget::close, Qt::UniqueConnection);
+        connect(d->closeButton, SIGNAL(clicked(bool)), this, SLOT(_q_quitActionTriggered()), Qt::UniqueConnection);
 
         d->updateButtonsState(d->targetWindow()->windowFlags());
     } else {


### PR DESCRIPTION
When clicking the close button, call the widget::close. 
Modify that calling dapplication::quit is the same as clicking the option to exit

Log: