### PR TITLE
fix: some windows have dual title bars

### DIFF
--- a/include/widgets/dtitlebar.h
+++ b/include/widgets/dtitlebar.h
@@ -119,6 +119,7 @@ private:
     D_PRIVATE_SLOT(void _q_toggleWindowState())
     D_PRIVATE_SLOT(void _q_showMinimized())
     D_PRIVATE_SLOT(void _q_onTopWindowMotifHintsChanged(quint32))
+    D_PRIVATE_SLOT(void _q_closeWindow())
 
 #ifndef QT_NO_MENU
     D_PRIVATE_SLOT(void _q_addDefaultMenuItems())

--- a/src/widgets/dabstractdialog.cpp
+++ b/src/widgets/dabstractdialog.cpp
@@ -40,11 +40,6 @@ void DAbstractDialogPrivate::init(bool blurIfPossible)
     // TODO: 这里对dialog特殊处理，dialog不需要设置固定的位置，否则里面的坐标会发生偏移导致点击偏移
     // 但是这不是问题的根本原因，还需要进一步分析。该属性在插件中做了特殊处理
     q->QDialog::setProperty("DAbstractDialog", true);
-    auto noTitlebarEnabled = []{
-        QFunctionPointer enableNoTitlebar = qApp->platformFunction("_d_isEnableNoTitlebar");
-        bool enabled = qApp->platformName() == "dwayland" || qApp->property("_d_isDwayland").toBool();
-        return enabled && enableNoTitlebar != nullptr;
-    };
 
     if (qApp->isDXcbPlatform()) {
         handle = new DPlatformWindowHandle(q, q);
@@ -66,7 +61,7 @@ void DAbstractDialogPrivate::init(bool blurIfPossible)
 
         bgBlurWidget->setBlurEnabled(blurIfPossible);
         q->setAttribute(Qt::WA_TranslucentBackground, blurIfPossible);
-    } else if (noTitlebarEnabled()) {
+    } else if (DWindowManagerHelper::instance()->hasNoTitlebar()) {
         handle = new DPlatformWindowHandle(q, q);
 
         if (!handle->enableBlurWindow()) {

--- a/src/widgets/dfloatingmessage.cpp
+++ b/src/widgets/dfloatingmessage.cpp
@@ -12,6 +12,7 @@
 #include <QLabel>
 #include <QDebug>
 #include <QGraphicsDropShadowEffect>
+#include <QWindow>
 
 class MessageLabel : public QLabel
 {
@@ -79,15 +80,16 @@ void DFloatingMessagePrivate::init()
         closeButton->setIconSize(DSizeModeHelper::element(QSize(20, 20), QSize(32, 32)));
 
         hBoxLayout->addWidget(closeButton);
-        q->connect(closeButton, &DIconButton::clicked, q, &DFloatingMessage::closeButtonClicked);
 
-        if(ENABLE_ANIMATIONS && ENABLE_ANIMATION_MESSAGE)
-            q->connect(closeButton, &DIconButton::clicked, q, [q]() {
-                q->close();
+        q->connect(closeButton, &DIconButton::clicked, q, [q]() {
+            if (q->windowHandle()) {
+                q->windowHandle()->close();
+            }
+            if(ENABLE_ANIMATIONS && ENABLE_ANIMATION_MESSAGE) {
                 Q_EMIT q->messageClosed();
-            });
-        else
-            q->connect(closeButton, &DIconButton::clicked, q, &DFloatingMessage::close);
+            }
+            Q_EMIT q->closeButtonClicked();
+        });
     }
 
     if (!ENABLE_ANIMATIONS || !ENABLE_ANIMATION_MESSAGE)

--- a/src/widgets/dmainwindow.cpp
+++ b/src/widgets/dmainwindow.cpp
@@ -24,6 +24,7 @@
 #include <qwidgetaction.h>
 #include <QScreen>
 
+#include <DWindowManagerHelper>
 #include <DAnchors>
 #include <DConfig>
 
@@ -42,15 +43,8 @@ DMainWindowPrivate::DMainWindowPrivate(DMainWindow *qq)
 {
     titlebar = new DTitlebar(qq);
     titlebar->setAccessibleName("DMainWindowTitlebar");
-    auto noTitlebarEnabled = []{
-        if (DGuiApplicationHelper::testAttribute(DGuiApplicationHelper::IsWaylandPlatform)) {
-            return true;
-        }
-        QFunctionPointer enableNoTitlebar = qApp->platformFunction("_d_isEnableNoTitlebar");
-        bool enabled = qApp->platformName() == "dwayland" || qApp->property("_d_isDwayland").toBool();
-        return enabled && enableNoTitlebar != nullptr;
-    };
-    if (DApplication::isDXcbPlatform() || noTitlebarEnabled()) {
+
+    if (DApplication::isDXcbPlatform() || DWindowManagerHelper::instance()->hasNoTitlebar()) {
         handle = new DPlatformWindowHandle(qq, qq);
         qq->setMenuWidget(titlebar);
     } else {

--- a/src/widgets/dtitlebar.cpp
+++ b/src/widgets/dtitlebar.cpp
@@ -79,6 +79,7 @@ private:
     void _q_toggleWindowState();
     void _q_showMinimized();
     void _q_onTopWindowMotifHintsChanged(quint32 winId);
+    void _q_closeWindow();
 
 #ifndef QT_NO_MENU
     void _q_addDefaultMenuItems();
@@ -569,6 +570,13 @@ void DTitlebarPrivate::_q_toggleWindowState()
     } else if (!parentWindow->isFullScreen()
                && (maxButton->isVisible())) {
         parentWindow->showMaximized();
+    }
+}
+
+void DTitlebarPrivate::_q_closeWindow()
+{
+    if (targetWindow()->windowHandle()) {
+        targetWindow()->windowHandle()->close();
     }
 }
 
@@ -1533,7 +1541,7 @@ void DTitlebar::setVisible(bool visible)
         connect(d->maxButton, SIGNAL(clicked()), this, SLOT(_q_toggleWindowState()), Qt::UniqueConnection);
         connect(this, SIGNAL(doubleClicked()), this, SLOT(_q_toggleWindowState()), Qt::UniqueConnection);
         connect(d->minButton, SIGNAL(clicked()), this, SLOT(_q_showMinimized()), Qt::UniqueConnection);
-        connect(d->closeButton, &DWindowCloseButton::clicked, d->targetWindow(), &QWidget::close, Qt::UniqueConnection);
+        connect(d->closeButton, SIGNAL(clicked()), this, SLOT(_q_closeWindow()), Qt::UniqueConnection);
 
         d->updateButtonsState(d->targetWindow()->windowFlags());
     } else {


### PR DESCRIPTION
- 使用windowhandle的close()去关闭窗口
- DDialog和DMainWindow适配Treeland

pms: BUG-286173