### PR TITLE
fix: resident floating message cannot be closed

### DIFF
--- a/src/widgets/dfloatingmessage.cpp
+++ b/src/widgets/dfloatingmessage.cpp
@@ -82,9 +82,8 @@ void DFloatingMessagePrivate::init()
         hBoxLayout->addWidget(closeButton);
 
         q->connect(closeButton, &DIconButton::clicked, q, [q]() {
-            if (q->windowHandle()) {
-                q->windowHandle()->close();
-            }
+            q->close();
+            
             if(ENABLE_ANIMATIONS && ENABLE_ANIMATION_MESSAGE) {
                 Q_EMIT q->messageClosed();
             }


### PR DESCRIPTION
windowHandle() is not created by default,
use close() instead.

Bug: PMS-297669