### PR TITLE
fix: missing QT_QPA_PLATFORM for DApplication

### DIFF
--- a/src/widgets/dapplication.cpp
+++ b/src/widgets/dapplication.cpp
@@ -561,8 +561,6 @@ DApplication::DApplication(int &argc, char **argv) :
     QApplication(argc, argv),
     DObject(*new DApplicationPrivate(this))
 {
-    qputenv("QT_QPA_PLATFORM", QByteArray());
-
     // FIXME: fix bug in nvidia prime workaround, do not know effoct, must test more!!!
     // 在龙芯和申威上，xcb插件中加载glx相关库（r600_dri.so等）会额外耗时1.xs（申威应该更长）
     if (


### PR DESCRIPTION
it's useful for children process. and like revert the commit
cbcb732b750a9861fd14bff91fee71927afbf995
