### PR TITLE
fix: 修复 桌面/文管文件，打开属性窗口闪烁

### DIFF
--- a/src/widgets/ddrawer.cpp
+++ b/src/widgets/ddrawer.cpp
@@ -68,8 +68,8 @@ void DDrawerPrivate::init()
     layout_contentLoader->addStretch();
 
     m_animation = new QPropertyAnimation(m_contentLoader, "height", qq);
-    m_animation->setDuration(200);
-    m_animation->setEasingCurve(QEasingCurve::InSine);
+    m_animation->setDuration(400);
+    m_animation->setEasingCurve(QEasingCurve::InQuad);
     qq->connect(m_animation, &QPropertyAnimation::valueChanged, qq, [qq] {
         qq->setFixedHeight(qq->sizeHint().height());
     });


### PR DESCRIPTION
窗管渲染动画问题,动画太快则会闪烁,窗管暂时无解决方案,经讨论后采用规避方案,优化动画时间和动画播放曲线
更改后在问题机L410, 还有L420自测均未再复现

Log: 修复 桌面/文管文件，打开属性窗口闪烁
Bug: https://pms.uniontech.com/bug-view-242611.html
     https://pms.uniontech.com/bug-view-242571.html
Influence: DTK DDrawer控件
Change-Id: I72bb837f6a4b1393555e7a55c382d5878147a4fd
