### PR TITLE
fix: PrintPreview can't switch orientation

### DIFF
--- a/src/widgets/dprintpreviewwidget.cpp
+++ b/src/widgets/dprintpreviewwidget.cpp
@@ -1399,9 +1399,7 @@ void DPrintPreviewWidget::setColorMode(const DPrinter::ColorMode &colorMode)
 void DPrintPreviewWidget::setOrientation(const DPrinter::Orientation &pageOrientation)
 {
     Q_D(DPrintPreviewWidget);
-    auto layout = d->previewPrinter->pageLayout();
-    layout.setOrientation(static_cast<QPageLayout::Orientation>(pageOrientation));
-    d->previewPrinter->setPageLayout(layout);
+    d->previewPrinter->setPageOrientation(static_cast<QPageLayout::Orientation>(pageOrientation));
     updatePreview();
 }
 


### PR DESCRIPTION
it's introduced when adapting to qt6 in the commit 637e3eb.

pms:BUG-298085
