### PR TITLE
fix: titlebar can't drag after close DAboutDialog

### DIFF
--- a/src/widgets/daboutdialog.cpp
+++ b/src/widgets/daboutdialog.cpp
@@ -459,9 +459,7 @@ void DAboutDialog::setProductIcon(const QIcon &icon)
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     d->logoLabel->setPixmap(icon.pixmap(windowHandle(), QSize(128, 128)));
 #else
-    winId(); // TODO: wait for checking
-    auto window = windowHandle();
-    d->logoLabel->setPixmap(icon.pixmap(QSize(128, 128), window->screen()->devicePixelRatio()));
+    d->logoLabel->setPixmap(icon.pixmap(QSize(128, 128), devicePixelRatio()));
 #endif
 }
 


### PR DESCRIPTION
There is no need to get dpr based on the window.
It causes the window can't get mouse event if using
new DAboutDialog(window)).

pms:BUG-304097
