### PR TITLE
fix: app crashed for DBlurEffectWidget in qt6

### DIFF
--- a/src/widgets/dblureffectwidget.cpp
+++ b/src/widgets/dblureffectwidget.cpp
@@ -932,6 +932,12 @@ void DBlurEffectWidget::paintEvent(QPaintEvent *event)
     if (!d->blurEnabled)
         return;
 
+    if (!d->isBehindWindowBlendMode()) {
+        // 此模式下是自行控制sourceImage的更新
+        if (d->blendMode != InWidgetBlend) {
+            updateBlurSourceImage(event->region());
+        }
+    }
     QPainter pa(this);
 
     if (d->blurRectXRadius > 0 || d->blurRectYRadius > 0) {
@@ -957,11 +963,6 @@ void DBlurEffectWidget::paintEvent(QPaintEvent *event)
     if (d->isBehindWindowBlendMode()) {
         pa.setCompositionMode(QPainter::CompositionMode_Source);
     } else {
-        // 此模式下是自行控制sourceImage的更新
-        if (d->blendMode != InWidgetBlend) {
-            updateBlurSourceImage(event->region());
-        }
-
         if (d->customSourceImage || !d->sourceImage.isNull()) {
             int radius = d->radius;
             qreal device_pixel_ratio = devicePixelRatioF();


### PR DESCRIPTION
it's maybe a feature for qt6, we can't modify backingStore when
readying the widget.

``` QWidget::paintEvent(QPaintEvent *event)
QPainter pa(this);
// pa.end() // it's ok when modifing backingStore.
QImage image(window()->backingStore()->handle()->toImage());
image.detach();
```

pms:BUG-304317
