### PR TITLE
fix: window filickering caused by animation for DDrawer

### DIFF
--- a/src/widgets/private/ddrawer_p.h
+++ b/src/widgets/private/ddrawer_p.h
@@ -25,6 +25,7 @@ public:
     ~DDrawerPrivate();
 
     void init();
+    void updateHeightDirect();
 
     QWidget *m_header = nullptr;
     QWidget *m_content = nullptr;
@@ -35,6 +36,7 @@ public:
     DHorizontalLine * m_hSeparator = nullptr;
     DHorizontalLine *m_bottom_separator = nullptr;
     QPropertyAnimation *m_animation = nullptr;
+    bool m_enableAnimation = false;
     bool m_expand = false;
     bool m_reservedPadding[7];
 


### PR DESCRIPTION
WM's animation is confliclt with Widget.
We disable DDrawer's animation when window is invisible, and
can use D_DTK_DISABLE_ANIMATIONS to disable it's animation.

pms:BUG-242611
