### PR TITLE
feat: increase fallback for password character

### DIFF
--- a/src/widgets/dstyle.cpp
+++ b/src/widgets/dstyle.cpp
@@ -2037,7 +2037,10 @@ int DStyle::styleHint(QStyle::StyleHint sh, const QStyleOption *opt, const QWidg
     case SH_ScrollView_FrameOnlyAroundContents:
         return false;
     case SH_LineEdit_PasswordCharacter:
-        return 0x26AB;
+        if (w && QFontMetrics(w->font()).inFont(QChar(0x26AB)))
+            return 0x26AB;
+
+	return 0x25CF;
     default:
         break;
     }


### PR DESCRIPTION
0x26ab code points support fewer fonts, so we added 0x25CF with a wider range of adaptability as a fallback

pms: BUG-305575