### PR TITLE
fix: accessing wild pointer for DAboutDialog

### DIFF
--- a/src/widgets/dapplication.cpp
+++ b/src/widgets/dapplication.cpp
@@ -1436,7 +1436,6 @@ void DApplication::handleAboutAction()
     if (d->aboutDialog) {
         d->aboutDialog->activateWindow();
         d->aboutDialog->raise();
-        d->aboutDialog->setLicenseEnabled(d->licenseDialog->isValid());
         if (DGuiApplicationHelper::isTabletEnvironment()) {
             d->aboutDialog->exec();
         } else {


### PR DESCRIPTION
acknowledgementLabel is wild pointer if DDialog::clearContents
is called.
aboutDialog->setLicenseEnabled is not need to call when reactive
the dialog

pms: TASK-368399
