### PR TITLE
fix: DFloatingMessage宽度计算

### DIFF
--- a/src/widgets/dfloatingmessage.cpp
+++ b/src/widgets/dfloatingmessage.cpp
@@ -19,7 +19,7 @@ class MessageLabel : public QLabel
 public:
     QSize sizeHint() const override
     {
-        return fontMetrics().size(Qt::TextSingleLine, text());
+        return fontMetrics().size({}, text());
     }
 };
 DWIDGET_BEGIN_NAMESPACE


### PR DESCRIPTION
 DFloatingMessage的子控件MessageLabel支持自动换行，当文本内容包含换行符的时候，通过TextSingleLine计算的Size会与实际不符，导致整个控件宽度过大

Log:
Influence: DFloatingMessage的显示效果
Bug: https://pms.uniontech.com/bug-view-308569.html
Change-Id: I571a4c24d84cabfabaaf4a70bca8ec931347b157
