### PR TITLE
fix: DToolTip宽度计算

### DIFF
--- a/src/widgets/dtooltip.cpp
+++ b/src/widgets/dtooltip.cpp
@@ -182,7 +182,7 @@ DToolTip::DToolTip(const QString &text, bool completionClose)
 QSize DToolTip::sizeHint() const
 {
     int radius = DStyleHelper(style()).pixelMetric(DStyle::PM_FrameRadius);
-    QSize fontSize = fontMetrics().size(Qt::TextSingleLine, text());
+    QSize fontSize = fontMetrics().size({}, text());
 
     fontSize.setWidth(fontSize.width() + radius);
 


### PR DESCRIPTION
 DToolTip的SizeHint指定了用单行计算，当DToolTip设置了自动换行，并且文本包含换行符时，会导致计算的宽度错误

Log:
Influence: DToolTip
Bug: https://pms.uniontech.com/bug-view-308569.html
Change-Id: I690a85f34b961a531444d32fe43b3a50ef38dc51
