### PR TITLE
fix: 修复SwitchButton在透明窗口上显示时颜色太亮,太突兀的问题

### DIFF
--- a/src/widgets/dstyle.cpp
+++ b/src/widgets/dstyle.cpp
@@ -1301,7 +1301,10 @@ void DStyle::drawPrimitive(const QStyle *style, DStyle::PrimitiveElement pe, con
 
             p->setRenderHint(QPainter::Antialiasing);
             p->setPen(Qt::NoPen);
-            p->setBrush(dstyle.getColor(opt, QPalette::Button));
+            // SwitchButton用在透明窗口上底色太亮，很突兀，用带有透明度的黑色和白色替代
+            QColor color = DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::DarkType ? Qt::white : Qt::black;
+            color.setAlphaF(0.2);
+            p->setBrush(color);
             p->drawRoundedRect(rectGroove, frame_radius, frame_radius);
         }
         break;


### PR DESCRIPTION
原本使用的色板中button的颜色,现改为带透明度的黑色和白色

Log: 修复SwitchButton在透明窗口上显示时颜色太亮,太突兀的问题
Bug: https://pms.uniontech.com/bug-view-250757.html
Influence: DTK SwitchButton按钮 (开关)
Change-Id: Ifb231a3a9ec548d6970d240eaf2667e50ffed9f3
