### PR TITLE
fix: wheel event is accepted in qt6

### DIFF
--- a/src/widgets/private/settings/combobox.cpp
+++ b/src/widgets/private/settings/combobox.cpp
@@ -14,5 +14,7 @@ void ComboBox::wheelEvent(QWheelEvent *e)
 {
     if (hasFocus()) {
         QComboBox::wheelEvent(e);
+    } else {
+        return QWidget::wheelEvent(e);
     }
 }


### PR DESCRIPTION
QApplication::notify has change the default action
``` qapplication.cpp
we.setAccepted(true);
we.m_spont = wheel->spontaneous() && w == receiver;
res = d->notify_helper(w, &we);
eventAccepted = we.isAccepted();
```
Event is accepted if we don't call parent class event function,
it cause event will not be passed on to it's parentWidget.
and it's different with qt5.

pms: BUG-306251
