### PR TITLE
fix: DTipLabel文本默认对齐方式

### DIFF
--- a/include/widgets/dalertcontrol.h
+++ b/include/widgets/dalertcontrol.h
@@ -30,6 +30,8 @@ public:
     void setAlertColor(QColor c);
     QColor alertColor() const;
     QColor defaultAlertColor() const;
+    void setAlertAlignment(Qt::Alignment alignment);
+    Qt::Alignment alertAlignment() const;
     void setMessageAlignment(Qt::Alignment alignment);
     Qt::Alignment messageAlignment() const;
     void showAlertMessage(const QString &text, int duration = 3000);

--- a/include/widgets/dlineedit.h
+++ b/include/widgets/dlineedit.h
@@ -34,6 +34,8 @@ public:
     bool isAlert() const;
     void showAlertMessage(const QString &text, int duration = 3000);
     void showAlertMessage(const QString &text, QWidget *follower, int duration = 3000);
+    void setAlertAlignment(Qt::Alignment alignment);
+    Qt::Alignment alertAlignment() const;
     void setAlertMessageAlignment(Qt::Alignment alignment);
     Qt::Alignment alertMessageAlignment() const;
     void hideAlertMessage();

--- a/src/widgets/dalertcontrol.cpp
+++ b/src/widgets/dalertcontrol.cpp
@@ -158,11 +158,11 @@ QColor DAlertControl::alertColor() const
 
 /*!
 @~english
-  \brief DAlertControl::setMessageAlignmentSpecify the alignment method Now only support the left, right, center, default left
+  \brief DAlertControl::setAlertAlignment Specify the alignment method Now only support the left, right, center, default left
   \note When the parameters are other, the default left
   \a alignment 消息对齐方式
  */
-void DAlertControl::setMessageAlignment(Qt::Alignment alignment)
+void DAlertControl::setAlertAlignment(Qt::Alignment alignment)
 {
     D_D(DAlertControl);
     d->alignment = alignment;
@@ -170,12 +170,34 @@ void DAlertControl::setMessageAlignment(Qt::Alignment alignment)
 
 /*!
 @~english
-  \brief DAlertControl::messageAlignment Return to the current alarm Tooltips alignment method
+  \brief DAlertControl::alertAlignment Return to the current alarm Tooltips alignment method
+ */
+Qt::Alignment DAlertControl::alertAlignment() const
+{
+    D_DC(DAlertControl);
+    return d->alignment;
+}
+
+/*!
+@~english
+  \brief DAlertControl::setMessageAlignment Specify the alignment method Now only support the left, right, center, default center
+  \note When the parameters are other, the default center
+  \a alignment 文本内容对齐方式
+ */
+void DAlertControl::setMessageAlignment(Qt::Alignment alignment)
+{
+    D_D(DAlertControl);
+    d->messageAlignment = alignment;
+}
+
+/*!
+@~english
+  \brief DAlertControl::messageAlignment Return to the current tooltip message alignment method
  */
 Qt::Alignment DAlertControl::messageAlignment() const
 {
     D_DC(DAlertControl);
-    return d->alignment;
+    return d->messageAlignment;
 }
 
 /*!
@@ -216,6 +238,7 @@ void DAlertControl::showAlertMessage(const QString &text, QWidget *follower, int
         d->tooltip->setAccessibleName("DAlertControlAlertToolTip");
         d->tooltip->setForegroundRole(DPalette::TextWarning);
         d->tooltip->setWordWrap(true);
+        d->tooltip->setAlignment(d->messageAlignment);
 
         d->frame = new DFloatingWidget;
         d->frame->setAccessibleName("DAlertControlFloatingWidget");

--- a/src/widgets/dlineedit.cpp
+++ b/src/widgets/dlineedit.cpp
@@ -129,6 +129,18 @@ void DLineEdit::showAlertMessage(const QString &text, QWidget *follower, int dur
   \note When the parameter is other, the default left alignment
   \a alignment Message alignment
  */
+void DLineEdit::setAlertAlignment(Qt::Alignment alignment)
+{
+    D_D(DLineEdit);
+    d->control->setAlertAlignment(alignment);
+}
+
+Qt::Alignment DLineEdit::alertAlignment() const
+{
+    D_DC(DLineEdit);
+    return d->control->alertAlignment();
+}
+
 void DLineEdit::setAlertMessageAlignment(Qt::Alignment alignment)
 {
     D_D(DLineEdit);

--- a/src/widgets/dtiplabel.cpp
+++ b/src/widgets/dtiplabel.cpp
@@ -82,7 +82,6 @@ DTipLabelPrivate::DTipLabelPrivate(DTipLabel *q)
 void DTipLabelPrivate::init()
 {
     Q_Q(DTipLabel);
-    q->setAlignment(Qt::AlignCenter);
 
     DFontSizeManager::instance()->bind(q, DFontSizeManager::T7);
 }

--- a/src/widgets/private/dalertcontrol_p.h
+++ b/src/widgets/private/dalertcontrol_p.h
@@ -27,6 +27,7 @@ private:
     QPointer<QWidget> target;
     QColor  alertColor;
     Qt::Alignment alignment{Qt::AlignLeft};
+    Qt::Alignment messageAlignment{Qt::AlignLeft};
     QTimer timer;
 };
 


### PR DESCRIPTION
 DTipLabel的尺寸

Log:
Influence: DAlertControl
Change-Id: I251400365fc6fdc29ee1cb1f11efdc81eaf2d939