### PR TITLE
style: adjust website link style in about dialog

### DIFF
--- a/src/widgets/daboutdialog.cpp
+++ b/src/widgets/daboutdialog.cpp
@@ -32,7 +32,7 @@
 DCORE_USE_NAMESPACE
 DWIDGET_BEGIN_NAMESPACE
 
-const QString DAboutDialogPrivate::websiteLinkTemplate = "<a href='%1' style='text-decoration: none; font-size:12px; color: rgba(0,129,255,0.9);'>%2</a>";
+const QString DAboutDialogPrivate::websiteLinkTemplate = "<a href='%1' style='text-decoration: none; color: rgba(0,129,255,0.9);'>%2</a>";
 
 DRedPointLabel::DRedPointLabel(QWidget *parent)
     : QLabel(parent)
@@ -92,6 +92,7 @@ void DAboutDialogPrivate::init()
     websiteLabel->setObjectName("WebsiteLabel");
     websiteLabel->setContextMenuPolicy(Qt::NoContextMenu);
     websiteLabel->setOpenExternalLinks(false);
+    fontManager->bind(websiteLabel, DFontSizeManager::T8, QFont::Medium);
     updateWebsiteLabel();
 
     descriptionLabel = new QLabel();


### PR DESCRIPTION
1. Removed fixed font-size from website link template to use consistent
font sizing
2. Added font binding for website label using font manager with T8 size
and Medium weight
3. This ensures consistent typography across the application and better
accessibility

style: 调整关于对话框中网站链接样式

1. 从网站链接模板中移除固定字体大小，改用一致的字体大小设置
2. 为网站标签添加字体管理器绑定，使用T8大小和中等等级
3. 确保应用程序中一致的排版和更好的可访问性

pms: BUG-314767
