### PR TITLE
fix: correct text elision behavior with shortcuts

### DIFF
--- a/src/widgets/dlabel.cpp
+++ b/src/widgets/dlabel.cpp
@@ -210,7 +210,7 @@ void DLabel::paintEvent(QPaintEvent *event)
             QString text = d->text;
             if (elideMode() != Qt::ElideNone) {
                 const QFontMetrics fm(fontMetrics());
-                text = fm.elidedText(text, elideMode(), width(), Qt::TextShowMnemonic);
+                text = fm.elidedText(text, elideMode(), width(), flags);
             }
             const DToolTip::ToolTipShowMode &toolTipShowMode = DToolTip::toolTipShowMode(this);
             if (toolTipShowMode != DToolTip::Default) {


### PR DESCRIPTION
Fixed the text elision behavior in DLabel to properly handle cases
where the label contains shortcut mnemonics. The change modifies the
Qt::TextShowMnemonic flag to only be applied when the label actually has
a shortcut (d->hasShortcut). This prevents incorrect text display when
eliding labels without shortcuts.

fix: 修正带快捷键标签的文本省略行为

修复了 DLabel 中文本省略行为，正确处理包含快捷键助记符的情况。修改了
Qt::TextShowMnemonic 标志，使其仅在标签实际具有快捷键(d->hasShortcut)时
应用。这防止了在没有快捷键的标签上出现错误的文本显示。

pms: BUG-285143
