### PR TITLE
fix: make version optional in release workflow and update spec file

### DIFF
--- a/.github/workflows/call-auto-release.yml
+++ b/.github/workflows/call-auto-release.yml
@@ -5,7 +5,7 @@ on:
       version:
         description: 'Release version (e.g., 1.0.0)'
         type: string
-        required: true
+        required: false
       name:
         description: 'The name of the person to release the version'
         type: string

--- a/rpm/dtkwidget.spec
+++ b/rpm/dtkwidget.spec
@@ -1,6 +1,6 @@
 Name:           dtkwidget
-Version: 5.7.17
-Release: 1
+Version:        5.7.17
+Release:        1%{?dist}
 Summary:        Deepin tool kit widget modules
 License:        LGPLv3+
 URL:            https://github.com/linuxdeepin/dtkwidget


### PR DESCRIPTION
1. Changed version parameter to be optional in GitHub workflow to allow
more flexible release process
2. Updated rpm spec file formatting for consistency and added %{?dist}
macro for proper package naming

The changes allow for:
- More flexible release process where version can be omitted
- Better formatted spec file with proper dist macro for package naming

fix: 使发布工作流中的版本可选并更新spec文件

1. 将GitHub工作流中的版本参数改为可选，以实现更灵活的发布流程
2. 更新rpm spec文件格式以保持一致性，并添加%{?dist}宏以正确命名包

这些更改允许：
- 更灵活的发布流程，可以省略版本号
- 格式更好的spec文件，带有正确的dist宏用于包命名
