### PR TITLE
fix: prevent itemSpacing override in setBackgroundType

### DIFF
--- a/src/widgets/dlistview.cpp
+++ b/src/widgets/dlistview.cpp
@@ -776,14 +776,6 @@ void DListView::setBackgroundType(DStyledItemDelegate::BackgroundType background
 {
     if (DStyledItemDelegate *d = qobject_cast<DStyledItemDelegate *>(itemDelegate())) {
         d->setBackgroundType(backgroundType);
-
-        if (d->backgroundType() == DStyledItemDelegate::RoundedBackground) {
-            d->setItemSpacing(10);
-        } else if (d->backgroundType() == DStyledItemDelegate::ClipCornerBackground) {
-            d->setItemSpacing(1);
-        } else {
-            d->setItemSpacing(0);
-        }
     }
 }
 

--- a/src/widgets/dstyleditemdelegate.cpp
+++ b/src/widgets/dstyleditemdelegate.cpp
@@ -516,10 +516,23 @@ public:
         }
     }
 
+
+    inline int itemSpacing() const
+    {
+        if (spacing >= 0) 
+            return spacing;
+        const auto type = backgroundType & DStyledItemDelegate::BackgroundType_Mask;
+        if (type == DStyledItemDelegate::RoundedBackground)
+            return 10;
+        if (type == DStyledItemDelegate::ClipCornerBackground)
+            return 1;
+        return 0;
+    }
+
     DStyledItemDelegate::BackgroundType backgroundType = DStyledItemDelegate::NoBackground;
     QMargins margins;
     QSize itemSize;
-    int itemSpacing = 0;
+    int spacing = -1;
     QMap<QModelIndex, QList<QPair<QAction*, QRect>>> clickableActionMap;
     QAction *pressedAction = nullptr;
     QList<QPointer<QWidget>> lastWidgets;
@@ -1176,9 +1189,9 @@ QSize DStyledItemDelegate::sizeHint(const QStyleOptionViewItem &option, const QM
     const QListView * lv = qobject_cast<const QListView*>(option.widget);
     if (lv) {
         if (lv->flow() == QListView::LeftToRight) {
-            size.rwidth() += d->itemSpacing;
+            size.rwidth() += d->itemSpacing();
         } else {
-            size.rheight() += d->itemSpacing;
+            size.rheight() += d->itemSpacing();
         }
     }
 
@@ -1253,7 +1266,7 @@ int DStyledItemDelegate::spacing() const
 {
     D_DC(DStyledItemDelegate);
 
-    return d->itemSpacing;
+    return d->itemSpacing();
 }
 
 void DStyledItemDelegate::setBackgroundType(DStyledItemDelegate::BackgroundType type)
@@ -1297,7 +1310,7 @@ void DStyledItemDelegate::setItemSpacing(int spacing)
 {
     D_D(DStyledItemDelegate);
 
-    d->itemSpacing = spacing;
+    d->spacing = spacing;
 }
 
 void DStyledItemDelegate::initStyleOption(QStyleOptionViewItem *option, const QModelIndex &index) const
@@ -1353,9 +1366,9 @@ void DStyledItemDelegate::initStyleOption(QStyleOptionViewItem *option, const QM
     const QListView * lv = qobject_cast<const QListView*>(option->widget);
     if (lv) {
         if (lv->flow() == QListView::LeftToRight) {
-            option->rect.adjust(0, 0, 0 - d->itemSpacing, 0);
+            option->rect.adjust(0, 0, 0 - d->itemSpacing(), 0);
         } else {
-            option->rect.adjust(0, 0, 0, 0 - d->itemSpacing);
+            option->rect.adjust(0, 0, 0, 0 - d->itemSpacing());
         }
         if (lv->window() && lv->window()->isActiveWindow()) {
             option->state |= QStyle::State_Active;


### PR DESCRIPTION
1. Removed automatic itemSpacing adjustment in
DListView::setBackgroundType
2. Added itemSpacing() method in DStyledItemDelegate to dynamically
calculate spacing based on background type
3. Changed itemSpacing member to spacing with default value -1 to
indicate custom spacing
4. Updated all references to use the new itemSpacing() method

The changes prevent the itemSpacing value from being unintentionally
overwritten when setting backgroundType, while maintaining backward
compatibility with the default spacing values for different background
types. This gives more control to developers to set custom spacing
values that won't be overridden by background type changes.

fix: 修复设置背景类型时覆盖itemSpacing值的问题

1. 移除了DListView::setBackgroundType中自动调整itemSpacing的逻辑
2. 在DStyledItemDelegate中添加itemSpacing()方法根据背景类型动态计算间距
3. 将itemSpacing成员改为spacing并设置默认值-1表示自定义间距
4. 更新所有引用以使用新的itemSpacing()方法

这些修改防止了在设置backgroundType时意外覆盖itemSpacing值的问题，同时保
持了对不同背景类型默认间距值的向后兼容性。这为开发者提供了更多控制权，可
以设置不会被背景类型更改覆盖的自定义间距值。
