### PR TITLE
fix: resolve Qt6 compatibility issues

### DIFF
--- a/examples/collections/editexample.cpp
+++ b/examples/collections/editexample.cpp
@@ -373,7 +373,11 @@ DKeySequenceEditExample::DKeySequenceEditExample(QWidget *parent)
     closeLabel1->setFixedSize(72, 19);
     closeLabel1->setAlignment(Qt::AlignLeft);
     DKeySequenceEdit *closeEdit1 = new DKeySequenceEdit(this);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    closeEdit1->setKeySequence(QKeySequence(Qt::ALT | Qt::Key_F4));
+#else
     closeEdit1->setKeySequence(QKeySequence(Qt::ALT + Qt::Key_F4));
+#endif
     QLabel *closeLabel2 = new QLabel("关闭窗口", this);
     closeLabel2->setFixedSize(72, 19);
     closeLabel2->setAlignment(Qt::AlignLeft);

--- a/examples/collections/mainwindow.cpp
+++ b/examples/collections/mainwindow.cpp
@@ -313,18 +313,11 @@ void MainWindow::menuItemInvoked(QAction *action)
                             _printer->newPage();
 
                         // 给出调用方widget界面作为打印内容
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-                        double xscale = _printer->pageRect().width() / double(this->width());
-                        double yscale = _printer->pageRect().height() / double(this->height());
-                        double scale = qMin(xscale, yscale);
-                        painter.translate(_printer->pageRect().width() / 2.0, _printer->pageRect().height() / 2.0);
-#else
                         double xscale = _printer->pageLayout().paintRectPixels(_printer->resolution()).width() / double(this->width());
                         double yscale = _printer->pageLayout().paintRectPixels(_printer->resolution()).height() / double(this->height());
                         double scale = qMin(xscale, yscale);
                         painter.translate(_printer->pageLayout().paintRectPixels(_printer->resolution()).width() / 2.0,
                                           _printer->pageLayout().paintRectPixels(_printer->resolution()).height() /2.0);
-#endif
                         painter.scale(scale, scale);
                         painter.translate(-this->width() / 2, -this->height() / 2);
                         this->render(&painter);
@@ -333,11 +326,7 @@ void MainWindow::menuItemInvoked(QAction *action)
                         QFont font /*("CESI仿宋-GB2312")*/;
                         font.setPixelSize(16);
                         font = QFont(font, painter.device());
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-                        QRectF rect = _printer->pageRect();
-#else
                         QRectF rect = _printer->pageLayout().paintRectPixels(_printer->resolution());
-#endif
                         rect = QRectF(0, 0, rect.width(), rect.height());
                         painter.setFont(font);
                         // 画可用页面矩形,提供调试效果参考

--- a/include/widgets/dinputdialog.h
+++ b/include/widgets/dinputdialog.h
@@ -106,20 +106,20 @@ public:
 
     static QString getText(QWidget *parent, const QString &title, const QString &message,
                            QLineEdit::EchoMode echo = QLineEdit::Normal,
-                           const QString &text = QString(), bool *ok = 0, Qt::WindowFlags flags = Qt::WindowFlags{0},
+                           const QString &text = QString(), bool *ok = 0, Qt::WindowFlags flags = {},
                            Qt::InputMethodHints inputMethodHints = Qt::ImhNone);
 
     static QString getItem(QWidget *parent, const QString &title, const QString &message,
                            const QStringList &items, int current = 0, bool editable = true,
-                           bool *ok = 0, Qt::WindowFlags flags = Qt::WindowFlags{0},
+                           bool *ok = 0, Qt::WindowFlags flags = {},
                            Qt::InputMethodHints inputMethodHints = Qt::ImhNone);
 
     static int getInt(QWidget *parent, const QString &title, const QString &message, int value = 0,
                       int minValue = -2147483647, int maxValue = 2147483647,
-                      int step = 1, bool *ok = 0, Qt::WindowFlags flags = Qt::WindowFlags{0});
+                      int step = 1, bool *ok = 0, Qt::WindowFlags flags = {});
     static double getDouble(QWidget *parent, const QString &title, const QString &message, double value = 0,
                             double minValue = -2147483647, double maxValue = 2147483647,
-                            int decimals = 1, bool *ok = 0, Qt::WindowFlags flags = Qt::WindowFlags{0});
+                            int decimals = 1, bool *ok = 0, Qt::WindowFlags flags = {});
 
 protected:
     void showEvent(QShowEvent *e);

--- a/plugin/dtkuidemo/mainwindow.cpp
+++ b/plugin/dtkuidemo/mainwindow.cpp
@@ -128,7 +128,11 @@ MainWindow::MainWindow(QWidget *parent) :
     // 设置 key seq
     DKeySequenceEdit *keyEditer = ui->Dtk__Widget__DKeySequenceEdit;
     keyEditer->setAlignment(Qt::AlignCenter);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    keyEditer->setKeySequence(QKeySequence(Qt::CTRL | Qt::Key_A));      // 用|号，不要用+号
+#else
     keyEditer->setKeySequence(QKeySequence(Qt::CTRL + Qt::Key_A));      // 用+号不要用逗号
+#endif
     connect(ui->Dtk__Widget__DKeySequenceEdit, &DKeySequenceEdit::keySequenceChanged, [] (const QKeySequence &seq) {
         qDebug() << "Key sequence: " << seq;
     });

--- a/plugin/dtkuiplugin/dcustomermacrowidget.h
+++ b/plugin/dtkuiplugin/dcustomermacrowidget.h
@@ -7,6 +7,13 @@
 
 #include <QtUiPlugin/QDesignerCustomWidgetInterface>
 
+// 定义键位组合操作符，兼容DTK5和DTK6
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#define DTKEY_OPERATOR |
+#else
+#define DTKEY_OPERATOR +
+#endif
+
 #include <DFrame>
 #include <DArrowLineDrawer>
 #include <DButtonBox>
@@ -121,7 +128,7 @@ public:                                                                         
         }                                                                                                   \
         if (IS_SAME(UPPER_NAME, DKeySequenceEdit)) {                                                        \
             DKeySequenceEdit *w = new DKeySequenceEdit(parent);                                             \
-            w->setKeySequence(QKeySequence(Qt::CTRL + Qt::Key_A)); /* 用+号不要用逗号 */                      \
+            w->setKeySequence(QKeySequence(Qt::CTRL DTKEY_OPERATOR Qt::Key_A)); /* 用+号不要用逗号 */                      \
             return reinterpret_cast<UPPER_NAME *>(w);                                                       \
         }                                                                                                   \
         if (IS_SAME(UPPER_NAME, DWaterProgress)) {                                                          \

--- a/src/util/daccessibilitychecker.cpp
+++ b/src/util/daccessibilitychecker.cpp
@@ -95,7 +95,7 @@ void DAccessibilityCheckerPrivate::checkWidgetName()
     for (const QWidget *topLevelWidget : topLevelWidgets)
         childrenList.append(topLevelWidget->findChildren<QWidget *>());
 
-    for (auto child : qAsConst(childrenList)) {
+    for (auto child : std::as_const(childrenList)) {
         if (q->isIgnore(DAccessibilityChecker::Widget, child)) {
             widgetIgnoredCount++;
             continue;
@@ -134,7 +134,7 @@ void DAccessibilityCheckerPrivate::checkViewItemName()
     for (const QWidget *topLevelWidget : topLevelWidgets)
         listViewList.append(topLevelWidget->findChildren<QAbstractItemView *>());
 
-    for (auto absListView : qAsConst(listViewList)) {
+    for (auto absListView : std::as_const(listViewList)) {
         if (q->isIgnore(DAccessibilityChecker::ViewItem, absListView))
             continue;
 

--- a/src/widgets/daboutdialog.cpp
+++ b/src/widgets/daboutdialog.cpp
@@ -372,7 +372,11 @@ QPixmap DAboutDialog::companyLogo() const
 {
     D_DC(DAboutDialog);
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    return d->companyLogoLabel->pixmap(Qt::ReturnByValue);
+#else
     return d->companyLogoLabel->pixmap();
+#endif
 }
 
 /*!

--- a/src/widgets/dapplication.cpp
+++ b/src/widgets/dapplication.cpp
@@ -179,7 +179,7 @@ bool DApplicationPrivate::setSingleInstanceBySemaphore(const QString &key)
     singleInstance = tryAcquireSystemSemaphore(&ss);
 
     if (singleInstance) {
-        QtConcurrent::run([this] {
+        (void)QtConcurrent::run([this] {
             QPointer<DApplication> that = q_func();
 
             while (ss.acquire() && singleInstance)

--- a/src/widgets/ddialog.cpp
+++ b/src/widgets/ddialog.cpp
@@ -626,7 +626,7 @@ void DDialog::insertButton(int index, QAbstractButton *button, bool isDefault)
 
     const QString &text = button->text();
 
-    if (text.count() == 2) {
+    if (text.size() == 2) {
         for (const QChar &ch : text) {
             switch (ch.script()) {
             case QChar::Script_Han:

--- a/src/widgets/dimageviewer.cpp
+++ b/src/widgets/dimageviewer.cpp
@@ -909,7 +909,11 @@ bool DImageViewer::event(QEvent *event)
         }
         case QEvent::TouchUpdate: {
             QTouchEvent *touchEvent = dynamic_cast<QTouchEvent *>(event);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+            QList<QTouchEvent::TouchPoint> touchPoints = touchEvent->points();
+#else
             QList<QTouchEvent::TouchPoint> touchPoints = touchEvent->touchPoints();
+#endif
             if (touchPoints.size() > touchCount) {
                 touchCount = touchPoints.size();
             }
@@ -917,10 +921,18 @@ bool DImageViewer::event(QEvent *event)
         }
         case QEvent::TouchEnd: {
             QTouchEvent *touchEvent = dynamic_cast<QTouchEvent *>(event);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+            QList<QTouchEvent::TouchPoint> touchPoints = touchEvent->points();
+#else
             QList<QTouchEvent::TouchPoint> touchPoints = touchEvent->touchPoints();
+#endif
             if (touchPoints.size() == 1 && touchCount <= 1) {
                 // Swipe gesture.
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+                qreal offset = touchPoints.at(0).lastPosition().x() - touchPoints.at(0).pressPosition().x();
+#else
                 qreal offset = touchPoints.at(0).lastPos().x() - touchPoints.at(0).startPos().x();
+#endif
                 if (qAbs(offset) > 200) {
                     if (offset > 0) {
                         Q_EMIT requestPreviousImage();

--- a/src/widgets/dipv4lineedit.cpp
+++ b/src/widgets/dipv4lineedit.cpp
@@ -259,7 +259,7 @@ int DIpv4LineEdit::cursorPosition() const
             cursorPosition += edit->cursorPosition();
             break;
         } else {
-            cursorPosition += edit->text().count() + 1;
+            cursorPosition += edit->text().size() + 1;
         }
     }
 
@@ -339,8 +339,8 @@ void DIpv4LineEdit::setCursorPosition(int cursorPosition)
     D_D(DIpv4LineEdit);
 
     for (QLineEdit *edit : d->editList) {
-        if (cursorPosition > edit->text().count()) {
-            cursorPosition -= edit->text().count();
+        if (cursorPosition > edit->text().size()) {
+            cursorPosition -= edit->text().size();
             --cursorPosition;
         } else {
             edit->setCursorPosition(cursorPosition);
@@ -380,9 +380,9 @@ void DIpv4LineEdit::setSelection(int start, int length)
     D_D(DIpv4LineEdit);
 
     for (QLineEdit *edit : d->editList) {
-        if (edit->text().count() > start) {
-            if (edit->text().count() < length + start) {
-                int tmp_length = edit->text().count() - start;
+        if (edit->text().size() > start) {
+            if (edit->text().size() < length + start) {
+                int tmp_length = edit->text().size() - start;
 
                 edit->setSelection(start, tmp_length);
 
@@ -395,7 +395,7 @@ void DIpv4LineEdit::setSelection(int start, int length)
             edit->setSelection(edit->cursorPosition(), 0);
         }
 
-        start -= edit->text().count();
+        start -= edit->text().size();
     }
 
     QLineEdit::setSelection(start, length);
@@ -445,7 +445,7 @@ bool DIpv4LineEdit::eventFilter(QObject *obj, QEvent *e)
 
                 D_D(DIpv4LineEdit);
                 if (event->key() <= Qt::Key_9 && event->key() >= Qt::Key_0) {
-                    if (edit->cursorPosition() == edit->text().count()) {
+                    if (edit->cursorPosition() == edit->text().size()) {
                         QRegularExpression rx(RX_PATTERN_IP);
 
                         const QString number = QString::number(event->key() - Qt::Key_0);

--- a/src/widgets/dkeysequenceedit.cpp
+++ b/src/widgets/dkeysequenceedit.cpp
@@ -282,16 +282,26 @@ void DKeySequenceEdit::keyPressEvent(QKeyEvent *e)
             return;
         bool found = false;
         for (int i = 0; i < possibleKeys.size(); ++i) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+            if (possibleKeys.at(i).toCombined() - nextKey == static_cast<int>(e->modifiers())
+                || (possibleKeys.at(i).toCombined() == nextKey && e->modifiers() == Qt::ShiftModifier)) {
+                nextKey = possibleKeys.at(i).toCombined();
+#else
             if (static_cast<int>(possibleKeys.at(i)) - nextKey == static_cast<int>(e->modifiers())
                 || (possibleKeys.at(i) == nextKey && e->modifiers() == Qt::ShiftModifier)) {
                 nextKey = possibleKeys.at(i);
+#endif
                 found = true;
                 break;
             }
         }
         // Use as fallback
         if (!found)
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+            nextKey = possibleKeys.first().toCombined();
+#else
             nextKey = possibleKeys.first();
+#endif
     }
 
     QString modifiers = QKeySequence(e->modifiers()).toString();

--- a/src/widgets/dprintpreviewdialog.cpp
+++ b/src/widgets/dprintpreviewdialog.cpp
@@ -1145,7 +1145,11 @@ void DPrintPreviewDialogPrivate::initconnections()
             pageRangeError(NullTip);
         }
     });
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    QObject::connect(sidebysideCheckBox, &DCheckBox::checkStateChanged, q, [this](int status) {
+#else
     QObject::connect(sidebysideCheckBox, &DCheckBox::stateChanged, q, [this](int status) {
+#endif
         if (status == 0) {
             if (isActualPrinter(printDeviceCombo->currentText()))
                 settingHelper->setSubControlEnabled(DPrintPreviewSettingInterface::SC_PageOrder_SequentialPrint, true);
@@ -1257,7 +1261,11 @@ void DPrintPreviewDialogPrivate::initconnections()
     QObject::connect(marginRightSpin, SIGNAL(valueChanged(double)), q, SLOT(_q_marginspinChanged(double)));
     QObject::connect(marginLeftSpin, SIGNAL(valueChanged(double)), q, SLOT(_q_marginspinChanged(double)));
     QObject::connect(marginBottomSpin, SIGNAL(valueChanged(double)), q, SLOT(_q_marginspinChanged(double)));
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    QObject::connect(duplexCheckBox, SIGNAL(checkStateChanged(int)), q, SLOT(_q_checkStateChanged(int)));
+#else
     QObject::connect(duplexCheckBox, SIGNAL(stateChanged(int)), q, SLOT(_q_checkStateChanged(int)));
+#endif
     QObject::connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::themeTypeChanged, pview, &DPrintPreviewWidget::themeTypeChanged);
     QObject::connect(marginTopSpin, SIGNAL(editingFinished()), q, SLOT(_q_marginEditFinished()));
     QObject::connect(marginRightSpin, SIGNAL(editingFinished()), q, SLOT(_q_marginEditFinished()));

--- a/src/widgets/dprintpreviewwidget.cpp
+++ b/src/widgets/dprintpreviewwidget.cpp
@@ -51,7 +51,7 @@ static void saveImageToFile(int index, const QString &outPutFileName, const QStr
     QString tmpString = outPutFileName.left(outPutFileName.length() - suffix.length() - 1) + QString("(%1)").arg(QString::number(index + 1)) + stres;
 
     // 多线程保存文件修复大文件卡顿问题
-    QtConcurrent::run(QThreadPool::globalInstance(), [srcImage, tmpString, isJpegImage] {
+    (void)QtConcurrent::run(QThreadPool::globalInstance(), [srcImage, tmpString, isJpegImage] {
         const QFileInfo file(tmpString);
         const auto fileName = file.absolutePath() + "/" + truncateFileName(file.fileName());
         if (!srcImage.save(fileName, isJpegImage ? "JPEG" : "PNG")) {
@@ -114,7 +114,7 @@ void DPrintPreviewWidgetPrivate::populateScene()
     background->setBrush(Qt::white);
     background->setPen(Qt::NoPen);
 
-    for (auto *page : qAsConst(pages))
+    for (auto *page : std::as_const(pages))
         scene->removeItem(page);
     qDeleteAll(pages);
     pages.clear();
@@ -1152,13 +1152,13 @@ void DPrintPreviewWidgetPrivate::updateNumberUpContent()
 
     // 调整序号角标
     QVector<int> nVector;
-    for (auto &i : qAsConst(numberUpPrintData->previewPictures)) {
+    for (auto &i : std::as_const(numberUpPrintData->previewPictures)) {
         nVector.append(i.first);
     }
 
     // 调整序号坐标显示位置（纸张大小发生改变时）
     QVector<QPointF> paintPoints;
-    for (auto &p : qAsConst(numberUpPrintData->paintPoints)) {
+    for (auto &p : std::as_const(numberUpPrintData->paintPoints)) {
         paintPoints.append(p + QPointF(previewPrinter->pageLayout().paintRectPixels(previewPrinter->resolution()).width() * numberUpPrintData->scaleRatio, 0));
     }
 

--- a/src/widgets/dsettingswidgetfactory.cpp
+++ b/src/widgets/dsettingswidgetfactory.cpp
@@ -270,7 +270,11 @@ QPair<QWidget *, QWidget *> createCheckboxOptionHandle(QObject *opt)
     rightWidget->setAccessibleName("OptionCheckbox");
     rightWidget->setChecked(option->value().toBool());
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    option->connect(rightWidget, &QCheckBox::checkStateChanged,
+#else
     option->connect(rightWidget, &QCheckBox::stateChanged,
+#endif
     option, [ = ](int status) {
         option->setValue(status == Qt::Checked);
     });

--- a/src/widgets/dstyle.cpp
+++ b/src/widgets/dstyle.cpp
@@ -2117,7 +2117,7 @@ DStyle::StyleState DStyle::getState(const QStyleOption *option)
 
 static DStyle::StateFlags getFlags(const QStyleOption *option)
 {
-    DStyle::StateFlags flags{0};
+    DStyle::StateFlags flags{};
 
     if (option->state.testFlag(DStyle::State_On)) {
         flags |= DStyle::SS_CheckedFlag;

--- a/src/widgets/dstyleditemdelegate.cpp
+++ b/src/widgets/dstyleditemdelegate.cpp
@@ -490,7 +490,7 @@ public:
         if (lastWidgets.isEmpty() && currentWidgets.isEmpty())
             return;
 
-        for (const auto &widget : qAsConst(lastWidgets)) {
+        for (const auto &widget : std::as_const(lastWidgets)) {
             if (currentWidgets.contains(widget))
                 continue;
             if (widget && widget->isVisible())

--- a/src/widgets/dtabbar.cpp
+++ b/src/widgets/dtabbar.cpp
@@ -1049,8 +1049,13 @@ void DTabBarPrivate::startMove(int index)
 
 void DTabBarPrivate::stopMove()
 {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    QMouseEvent event(QEvent::MouseButtonRelease, mapFromGlobal(QCursor::pos()),
+                      QCursor::pos(), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+#else
     QMouseEvent event(QEvent::MouseButtonRelease, mapFromGlobal(QCursor::pos()),
                       Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+#endif
     bool movable = isMovable();
     setMovable(true);
     mouseReleaseEvent(&event);
@@ -1392,13 +1397,23 @@ void DTabBarPrivate::dragEnterEvent(QDragEnterEvent *e)
     if (e->source() == this) {
         e->acceptProposedAction();
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        QMouseEvent event(QEvent::MouseMove, e->position(),
+                          QCursor::pos(), Qt::LeftButton, e->buttons(),
+                          e->modifiers());
+#else
         QMouseEvent event(QEvent::MouseMove, e->posF(),
                           Qt::LeftButton, e->mouseButtons(),
                           e->keyboardModifiers());
+#endif
 
         mouseMoveEvent(&event);
     } else {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        int index = tabInsertIndexFromMouse(e->position().toPoint());
+#else
         int index = tabInsertIndexFromMouse(e->pos());
+#endif
 
         if (q_func()->canInsertFromMimeData(index, e->mimeData())) {
             setDragingFromOther(true);
@@ -1425,15 +1440,29 @@ void DTabBarPrivate::dragMoveEvent(QDragMoveEvent *e)
     if (e->source() == this) {
         e->acceptProposedAction();
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        QMouseEvent event(QEvent::MouseMove, e->position(),
+                          QCursor::pos(), Qt::LeftButton, e->buttons(),
+                          e->modifiers());
+#else
         QMouseEvent event(QEvent::MouseMove, e->posF(),
                           Qt::LeftButton, e->mouseButtons(),
                           e->keyboardModifiers());
+#endif
 
         mouseMoveEvent(&event);
     } else {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        autoScrollTabs(e->position().toPoint());
+#else
         autoScrollTabs(e->pos());
+#endif
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        int index = tabInsertIndexFromMouse(e->position().toPoint());
+#else
         int index = tabInsertIndexFromMouse(e->pos());
+#endif
 
         if (q_func()->canInsertFromMimeData(index, e->mimeData())) {
             setDragingFromOther(true);
@@ -1447,15 +1476,25 @@ void DTabBarPrivate::dropEvent(QDropEvent *e)
     if (e->source() == this) {
         e->acceptProposedAction();
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        QMouseEvent event(QEvent::MouseButtonRelease, e->position(),
+                          QCursor::pos(), Qt::LeftButton, e->buttons(),
+                          e->modifiers());
+#else
         QMouseEvent event(QEvent::MouseButtonRelease, e->posF(),
                           Qt::LeftButton, e->mouseButtons(),
                           e->keyboardModifiers());
+#endif
 
         mouseReleaseEvent(&event);
     } else {
         setDragingFromOther(false);
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        int index = tabInsertIndexFromMouse(e->position().toPoint());
+#else
         int index = tabInsertIndexFromMouse(e->pos());
+#endif
 
         if (q_func()->canInsertFromMimeData(index, e->mimeData())) {
             e->acceptProposedAction();
@@ -2337,7 +2376,11 @@ void DTabBar::dragEnterEvent(QDragEnterEvent *e)
     if (e->source() == d)
         return QWidget::dragEnterEvent(e);
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    int index = d->tabInsertIndexFromMouse(d->mapFromParent(e->position().toPoint()));
+#else
     int index = d->tabInsertIndexFromMouse(d->mapFromParent(e->pos()));
+#endif
 
     if (canInsertFromMimeData(index, e->mimeData())) {
         d->setDragingFromOther(true);
@@ -2378,7 +2421,11 @@ void DTabBar::dragMoveEvent(QDragMoveEvent *e)
     if (e->source() == d)
         return QWidget::dragMoveEvent(e);
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    int index = d->dd()->validIndex(d->ghostTabIndex) ? d->ghostTabIndex : d->tabInsertIndexFromMouse(d->mapFromParent(e->position().toPoint()));
+#else
     int index = d->dd()->validIndex(d->ghostTabIndex) ? d->ghostTabIndex : d->tabInsertIndexFromMouse(d->mapFromParent(e->pos()));
+#endif
     bool canInsert = false;
 
     if (canInsertFromMimeData(index, e->mimeData())) {
@@ -2394,8 +2441,13 @@ void DTabBar::dragMoveEvent(QDragMoveEvent *e)
     if (e->source() != d) {
         if (canInsert) {
             if (d->dd()->validIndex(d->ghostTabIndex)) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+                QMouseEvent event(QEvent::MouseMove, d->mapFromParent(e->position().toPoint()),
+                                  d->mapFromParent(e->position().toPoint()), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+#else
                 QMouseEvent event(QEvent::MouseMove, d->mapFromParent(e->pos()),
                                   Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+#endif
                 d->mouseMoveEvent(&event);
             } else {
                 d->ghostTabIndex = index;
@@ -2403,7 +2455,11 @@ void DTabBar::dragMoveEvent(QDragMoveEvent *e)
                 d->startMove(index);
             }
         } else {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+            d->autoScrollTabs(d->mapFromParent(e->position().toPoint()));
+#else
             d->autoScrollTabs(d->mapFromParent(e->pos()));
+#endif
         }
     }
 }
@@ -2418,7 +2474,11 @@ void DTabBar::dropEvent(QDropEvent *e)
     d->setDragingFromOther(false);
     d->stopAutoScrollTabs();
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    int index = d->tabInsertIndexFromMouse(d->mapFromParent(e->position().toPoint()));
+#else
     int index = d->tabInsertIndexFromMouse(d->mapFromParent(e->pos()));
+#endif
 
     if (canInsertFromMimeData(index, e->mimeData())) {
         e->acceptProposedAction();

--- a/src/widgets/dtooltip.cpp
+++ b/src/widgets/dtooltip.cpp
@@ -100,7 +100,7 @@ QString DToolTip::wrapToolTipText(QString text, QTextOption option)
     QStringList paragraphs = text.split('\n');
     const QFont &toolTipFont = QToolTip::font();
     QString toolTip{""};
-    for (const QString &paragraph : qAsConst(paragraphs))
+    for (const QString &paragraph : std::as_const(paragraphs))
     {
         if (paragraph.isEmpty())
             continue;

--- a/src/widgets/private/dprintpreviewwidget_p.h
+++ b/src/widgets/private/dprintpreviewwidget_p.h
@@ -543,7 +543,7 @@ struct DPrintPreviewWidgetPrivate::NumberUpData {
         if (waterList.isEmpty())
             return;
 
-        for (auto *item : qAsConst(waterList))
+        for (auto *item : std::as_const(waterList))
             item->update();
     }
 
@@ -556,7 +556,7 @@ struct DPrintPreviewWidgetPrivate::NumberUpData {
         auto *firstWm = waterList.first();
         outFunction(firstWm);
 
-        for (auto *item : qAsConst(waterList)) {
+        for (auto *item : std::as_const(waterList)) {
             if (item == firstWm)
                 continue;
 

--- a/src/widgets/private/dtitlebareditpanel.cpp
+++ b/src/widgets/private/dtitlebareditpanel.cpp
@@ -727,7 +727,11 @@ void DTitlebarEditPanel::handleTitlebarZoneWidgetMoveEvent(QDropEvent *event)
     QSize size;
     dataStream >> key >> hotSpot >> size;
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    positionPlaceHolder(event->position().toPoint(), hotSpot, size);
+#else
     positionPlaceHolder(event->pos(), hotSpot, size);
+#endif
     Q_EMIT startScreenShot();
 }
 
@@ -744,7 +748,11 @@ void DTitlebarEditPanel::handleSelectionZoneWidgetMoveEvent(QDropEvent *event)
     QSize size;
     dataStream >> key >> hotSpot >> size;
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    positionPlaceHolder(event->position().toPoint(), hotSpot, size);
+#else
     positionPlaceHolder(event->pos(), hotSpot, size);
+#endif
     Q_EMIT startScreenShot();
 }
 

--- a/src/widgets/private/dtitlebarsettingsimpl.cpp
+++ b/src/widgets/private/dtitlebarsettingsimpl.cpp
@@ -474,7 +474,7 @@ DTitlebarToolFactory::~DTitlebarToolFactory()
 void DTitlebarToolFactory::add(DTitlebarToolBaseInterface *tool)
 {
     bool exist = false;
-    for (const auto &item : qAsConst(m_tools)) {
+    for (const auto &item : std::as_const(m_tools)) {
         if (item.tool->id() == tool->id()) {
             exist =  true;
             break;
@@ -495,7 +495,7 @@ void DTitlebarToolFactory::remove(const QString &id)
 void DTitlebarToolFactory::setTools(const QList<DTitlebarToolBaseInterface *> &tools)
 {
     m_tools.clear();
-    for (auto tool : qAsConst(tools))
+    for (auto tool : std::as_const(tools))
         m_tools[tool->id()] = ToolWrapper{tool};
 }
 

--- a/tests/testcases/widgets/ut_dslider.cpp
+++ b/tests/testcases/widgets/ut_dslider.cpp
@@ -101,10 +101,10 @@ TEST_F(ut_DSlider, testDSliderss)
     aboveTicks << "above tick 1" <<  "above tick 2";
     belowTicks << "below tick 1" <<  "below tick 2";
 
-    dslider->setLeftTicks(qAsConst(leftTicks));
-    dslider->setRightTicks(qAsConst(rightTicks));
-    dslider->setAboveTicks(qAsConst(aboveTicks));
-    dslider->setBelowTicks(qAsConst(belowTicks));
+    dslider->setLeftTicks(std::as_const(leftTicks));
+    dslider->setRightTicks(std::as_const(rightTicks));
+    dslider->setAboveTicks(std::as_const(aboveTicks));
+    dslider->setBelowTicks(std::as_const(belowTicks));
 
     // TODO 是否考虑预留接口以获取 leftTicks、rightTicks、aboveTicks、belowTicks
 }


### PR DESCRIPTION
1. Replace deprecated qAsConst with std::as_const for Qt6 compatibility
2. Update key sequence handling to use | operator instead of + for Qt6
3. Fix touch event handling for Qt6 API changes
4. Replace stateChanged with checkStateChanged for Qt6 checkbox signals
5. Add version checks for Qt6-specific API changes
6. Fix various other Qt6 deprecation warnings

These changes ensure the codebase works correctly with both Qt5 and
Qt6, addressing API changes and deprecations in Qt6 while maintaining
backward compatibility. Key technical changes include:
- Using Qt version checks for API differences
- Standardizing on newer APIs where possible
- Maintaining compatibility with both major Qt versions

fix: 解决Qt6兼容性问题

1. 使用std::as_const替代已弃用的qAsConst以兼容Qt6
2. 更新键序列处理，在Qt6中使用|运算符而非+
3. 修复Qt6中触摸事件处理的API变更
4. 将stateChanged替换为checkStateChanged以适配Qt6复选框信号
5. 添加Qt6特定API变更的版本检查
6. 修复其他Qt6弃用警告

这些修改确保代码库能正确工作在Qt5和Qt6环境下，解决了Qt6中的API变更和弃用
问题，同时保持向后兼容性。关键技术变更包括：
- 针对API差异使用Qt版本检查
- 尽可能标准化使用新API
- 保持对两个主要Qt版本的兼容性
