### PR TITLE
fix: prevent potential tab index out of bounds crash

### DIFF
--- a/src/widgets/dtabbar.cpp
+++ b/src/widgets/dtabbar.cpp
@@ -687,6 +687,7 @@ void DTabBarPrivate::layoutTab(int index)
     Q_ASSERT(index >= 0);
     QTabBarPrivate *d = reinterpret_cast<QTabBarPrivate *>(qGetPtrHelper(d_ptr));
     QTabBarPrivate::Tab *tab = d->at(index);
+    Q_ASSERT(tab);
     bool vertical = dtk_verticalTabs(d->shape);
 
     if (!(tab->leftWidget || tab->rightWidget))
@@ -1279,7 +1280,7 @@ void DTabBarPrivate::paintEvent(QPaintEvent *e)
     }
 
     // Draw the selected tab last to get it "on top"
-    if (selected >= 0) {
+    if (selected >= 0 && d->validIndex(selected)) {
         QStyleOptionTab tab;
         initStyleOption(&tab, selected);
         // 强制让文本居中


### PR DESCRIPTION
Added safety checks to prevent accessing invalid tab indices
1. Added Q_ASSERT(tab) in layoutTab to ensure tab pointer is valid
2. Added d->validIndex(selected) check in paintEvent before accessing
selected tab
3. Prevents crashes when tab index might be out of bounds during layout
or painting operations

fix: 修复标签索引越界可能导致的崩溃问题

添加安全检查防止访问无效的标签索引
1. 在layoutTab中添加Q_ASSERT(tab)确保标签指针有效
2. 在paintEvent中添加d->validIndex(selected)检查，确保在访问选中标签前索
引有效
3. 防止在布局或绘制操作中因标签索引越界而导致崩溃

PMS: BUG-331085
