### PR TITLE
fix: fix search icon color inconsistency in DSearchEdit

### DIFF
--- a/src/widgets/dsearchedit.cpp
+++ b/src/widgets/dsearchedit.cpp
@@ -20,6 +20,7 @@
 #endif
 
 #include <QAction>
+#include <QWidgetAction>
 #include <QPainter>
 #include <QDebug>
 #include <QLabel>
@@ -292,21 +293,27 @@ void DSearchEditPrivate::init()
 {
     D_Q(DSearchEdit);
     label = new QLabel;
-    DIconButton *iconbtn = new DIconButton(DStyle::SP_IndicatorSearch);
 
-    iconbtn->setFlat(true);
-    iconbtn->setFocusPolicy(Qt::NoFocus);
-    iconbtn->setAttribute(Qt::WA_TransparentForMouseEvents);
-    iconbtn->setAccessibleName("DSearchEditIconButton");
+    auto createSearchIconButton = []() {
+        DIconButton *iconbtn = new DIconButton(DStyle::SP_IndicatorSearch);
+        iconbtn->setFlat(true);
+        iconbtn->setFocusPolicy(Qt::NoFocus);
+        iconbtn->setAttribute(Qt::WA_TransparentForMouseEvents);
+        iconbtn->setAccessibleName("DSearchEditIconButton");
+        iconbtn->setIconSize(QSize(20, 20));
+        return iconbtn;
+    };
+
+    auto iconbtn = createSearchIconButton();
 
     placeHolder = qApp->translate("DSearchEdit", "Search");
 
-    action = new QAction(q);
+    action = new QWidgetAction(q);
     action->setObjectName("_d_search_leftAction");
-    action->setIcon(DIconTheme::findQIcon("search_indicator"));
+    auto iconAction = createSearchIconButton();
+    action->setDefaultWidget(iconAction);
     q->lineEdit()->addAction(action, QLineEdit::LeadingPosition);
-    action->setVisible(false);
-    iconbtn->setIconSize(QSize(20, 20));
+    action->defaultWidget()->setVisible(false);
 
     DPalette pe;
     QStyleOption opt;
@@ -405,7 +412,7 @@ void DSearchEditPrivate::_q_toEditMode(bool focus)
             q->lineEdit()->setTextMargins(textMargins);
             if (animation->direction() == QPropertyAnimation::Direction::Forward) {
                 iconWidget->setVisible(false);
-                action->setVisible(true);
+                action->defaultWidget()->setVisible(true);
                 lineEdit->setPlaceholderText(placeholderText);
             } else {
                 iconWidget->setVisible(true);
@@ -420,7 +427,7 @@ void DSearchEditPrivate::_q_toEditMode(bool focus)
         if (focus) {
             animation->setDirection(QPropertyAnimation::Direction::Forward);
         } else {
-            action->setVisible(false);
+            action->defaultWidget()->setVisible(false);
             animation->setDirection(QPropertyAnimation::Direction::Backward);
         }
 
@@ -429,11 +436,11 @@ void DSearchEditPrivate::_q_toEditMode(bool focus)
         animation->start();
     } else {
         if (focus  || !q->lineEdit()->text().isEmpty()) {
-            action->setVisible(true);
+            action->defaultWidget()->setVisible(true);
             iconWidget->setVisible(false);
             lineEdit->setPlaceholderText(placeholderText);
         } else {
-            action->setVisible(false);
+            action->defaultWidget()->setVisible(false);
             iconWidget->setVisible(true);
             lineEdit->setPlaceholderText(QString());
         }

--- a/src/widgets/private/dsearchedit_p.h
+++ b/src/widgets/private/dsearchedit_p.h
@@ -13,6 +13,7 @@
 
 QT_BEGIN_NAMESPACE
 class QAudioInput;
+class QWidgetAction;
 QT_END_NAMESPACE
 
 DWIDGET_BEGIN_NAMESPACE
@@ -32,7 +33,7 @@ public:
     void _q_clearFocus();
 
 public:
-    QAction *action;
+    QWidgetAction *action;
     QString placeHolder;
     QString placeholderText;
 


### PR DESCRIPTION
The search icon button in DSearchEdit had inconsistent foreground
colors because the action button was drawn by Qt without using the
control's palette foreground color. This change replaces QAction with
QWidgetAction to ensure the search icon inherits the correct palette
colors from the parent widget.

Changed QAction to QWidgetAction and created a DIconButton widget as the
default widget for the action. This allows the search icon to properly
inherit the palette foreground color from DSearchEdit instead of using
Qt's default styling. Also updated all visibility control calls to use
defaultWidget()->setVisible() instead of action->setVisible().

Log: Fixed search icon color inconsistency in search edit controls

Influence:
1. Test search edit control in different themes to verify icon color
consistency
2. Verify search icon visibility transitions during focus changes
3. Test search functionality remains unchanged
4. Check accessibility name is preserved for the icon button
5. Verify placeholder text behavior during mode transitions

fix: 修复DSearchEdit中搜索图标颜色不一致问题

DSearchEdit中的搜索图标按钮存在前景色不一致的问题，因为操作按钮由Qt绘
制，没有使用控件的调色板前景色。本次修改将QAction替换为QWidgetAction，确
保搜索图标正确继承父部件的调色板颜色。

将QAction改为QWidgetAction，并创建DIconButton小部件作为操作的
默认小部件。这使得搜索图标能够正确从DSearchEdit继承调色板前景
色，而不是使用Qt的默认样式。同时更新了所有可见性控制调用，使用
defaultWidget()->setVisible()代替action->setVisible()。

Log: 修复搜索编辑控件中搜索图标颜色不一致问题

Influence:
1. 在不同主题下测试搜索编辑控件，验证图标颜色一致性
2. 验证焦点变化时搜索图标可见性转换
3. 测试搜索功能保持不变
4. 检查图标按钮的无障碍名称是否保留
5. 验证模式转换时的占位符文本行为

PMS: BUG-315583
