### PR TITLE
feat: enhance window effect support detection

### DIFF
--- a/src/widgets/dprintpickcolorwidget.cpp
+++ b/src/widgets/dprintpickcolorwidget.cpp
@@ -66,6 +66,10 @@ void ColorButton::paintEvent(QPaintEvent *)
     }
 }
 
+static bool supportWindowEffect()
+{
+    return DWindowManagerHelper::instance()->hasComposite() && DWindowManagerHelper::instance()->hasBlurWindow();
+}
 DPrintPickColorWidget::DPrintPickColorWidget(QWidget *parent)
     : DWidget(parent)
     , pinterface(nullptr)
@@ -115,7 +119,7 @@ void DPrintPickColorWidget::initUI()
     pickColorBtn->setFixedSize(55, 36);
     pickColorBtn->setIcon(DIconTheme::findQIcon("dorpper_normal"));
     pickColorBtn->setIconSize(QSize(32, 32));
-    pickColorBtn->setEnabled(DWindowManagerHelper::instance()->hasComposite());
+    pickColorBtn->setEnabled(supportWindowEffect());
     rgbPickColorLayout->addWidget(rgbLabel);
     rgbPickColorLayout->addWidget(rEdit);
     rgbPickColorLayout->addWidget(gEdit);
@@ -162,7 +166,10 @@ void DPrintPickColorWidget::initConnection()
 
     connect(valueLineEdit, SIGNAL(textChanged(QString)), this, SLOT(slotEditColor(QString)));
     connect(DWindowManagerHelper::instance(), &DWindowManagerHelper::hasCompositeChanged, this, [this]() {
-        this->pickColorBtn->setEnabled(DWindowManagerHelper::instance()->hasComposite());
+        this->pickColorBtn->setEnabled(supportWindowEffect());
+    });
+    connect(DWindowManagerHelper::instance(), &DWindowManagerHelper::hasBlurWindowChanged, this, [this]() {
+        this->pickColorBtn->setEnabled(supportWindowEffect());
     });
 }
 


### PR DESCRIPTION
Added supportWindowEffect() function to check for both compositing and
blur window capabilities
Updated color picker button enable state to require both composite and
blur window support
Added connection to handle hasBlurWindowChanged signal for dynamic
enable state updates

This change ensures the color picker button is only enabled when both
compositing and blur window effects are supported by the window manager,
providing better user experience by preventing the button from being
enabled in environments where the picker functionality wouldn't work
properly due to missing window effects.

Log: Color picker button now requires both compositing and blur window
support to be enabled

Influence:
1. Test color picker button enable/disable state when changing window
manager compositing settings
2. Verify button state when blur window support is enabled/disabled
3. Test in environments with different window manager capabilities
4. Verify picker functionality works correctly when button is enabled

feat: 增强窗口效果支持检测

新增 supportWindowEffect() 函数检查合成和模糊窗口支持能力
更新颜色选择器按钮启用状态，要求同时具备合成和模糊窗口支持
添加处理 hasBlurWindowChanged 信号的连接，实现动态启用状态更新

此更改确保颜色选择器按钮仅在窗口管理器同时支持合成和模糊窗口效果时启用，
提供更好的用户体验，防止在缺少窗口效果的环境中启用按钮而导致功能无法正常
工作。

Log: 颜色选择器按钮现在需要同时支持合成和模糊窗口效果才能启用

Influence:
1. 测试更改窗口管理器合成设置时颜色选择器按钮的启用/禁用状态
2. 验证模糊窗口支持启用/禁用时的按钮状态
3. 在不同窗口管理器能力的环境中进行测试
4. 验证按钮启用时选择器功能正常工作

PMS: BUG-329555
