### PR TITLE
refactor: remove deprecated QRegExp, fix typos, replace Q_FOREACH wit…

### DIFF
--- a/src/widgets/dapplication.cpp
+++ b/src/widgets/dapplication.cpp
@@ -561,7 +561,7 @@ DApplication::DApplication(int &argc, char **argv) :
     QApplication(argc, argv),
     DObject(*new DApplicationPrivate(this))
 {
-    // FIXME: fix bug in nvidia prime workaround, do not know effoct, must test more!!!
+    // FIXME: fix bug in nvidia prime workaround, do not know effect, must test more!!!
     // 在龙芯和申威上，xcb插件中加载glx相关库（r600_dri.so等）会额外耗时1.xs（申威应该更长）
     if (
 #ifdef FORCE_RASTER_WIDGETS

--- a/src/widgets/dblureffectwidget.cpp
+++ b/src/widgets/dblureffectwidget.cpp
@@ -176,7 +176,7 @@ bool DBlurEffectWidgetPrivate::updateWindowBlurArea(QWidget *topLevelWidget)
 
     bool isExistMaskPath = false;
 
-    Q_FOREACH (const DBlurEffectWidget *w, blurEffectWidgetList) {
+    for (const auto *w : std::as_const(blurEffectWidgetList)) {
         if (!w->d_func()->blurEnabled) {
             continue;
         }
@@ -210,7 +210,7 @@ bool DBlurEffectWidgetPrivate::updateWindowBlurArea(QWidget *topLevelWidget)
     if (isExistMaskPath) {
         QList<QPainterPath> pathList;
 
-        Q_FOREACH (const DBlurEffectWidget *w, blurEffectWidgetList) {
+        for (const auto *w : std::as_const(blurEffectWidgetList)) {
             if (!w->d_func()->blurEnabled) {
                 continue;
             }
@@ -238,7 +238,7 @@ bool DBlurEffectWidgetPrivate::updateWindowBlurArea(QWidget *topLevelWidget)
 
         areaList.reserve(blurEffectWidgetList.size());
 
-        Q_FOREACH (const DBlurEffectWidget *w, blurEffectWidgetList) {
+        for (const auto *w : std::as_const(blurEffectWidgetList)) {
             if (!w->d_func()->blurEnabled) {
                 continue;
             }

--- a/src/widgets/dcrumbedit.cpp
+++ b/src/widgets/dcrumbedit.cpp
@@ -520,7 +520,7 @@ public:
             }
         }
 
-        Q_FOREACH(const DCrumbTextFormat &f, formats) {
+        for (const auto &f : std::as_const(formats)) {
             if (!crumbList.contains(f.text())) {
                 formats.remove(f.text());
                 formatsChanged = true;

--- a/src/widgets/ddrawergroup.cpp
+++ b/src/widgets/ddrawergroup.cpp
@@ -96,7 +96,7 @@ void DDrawerGroup::addExpand(DDrawer *expand, int id)
     if (d->expandMap.values().indexOf(expand) == -1){
         if (id == -1){
             int maxId = -1;
-            Q_FOREACH (int tmp, d->expandMap.keys()) {
+            for (int tmp : std::as_const(d->expandMap).keys()) {
                 maxId = qMax(tmp, maxId);
             }
 

--- a/src/widgets/dexpandgroup.cpp
+++ b/src/widgets/dexpandgroup.cpp
@@ -72,7 +72,7 @@ void DExpandGroup::addExpand(DBaseExpand *expand, int id)
     if (m_expandMap.values().indexOf(expand) == -1){
         if (id == -1){
             int maxId = -1;
-            Q_FOREACH (int tmp, m_expandMap.keys()) {
+            for (int tmp : std::as_const(m_expandMap).keys()) {
                 maxId = qMax(tmp, maxId);
             }
 

--- a/src/widgets/dprintpreviewdialog.cpp
+++ b/src/widgets/dprintpreviewdialog.cpp
@@ -1638,7 +1638,7 @@ void DPrintPreviewDialogPrivate::watermarkTypeChoosed(int index)
 #else
         QStringList fontList = QFontDatabase::families(QFontDatabase::Any);
 #endif
-        Q_FOREACH (const QString &font, fontList) {
+        for (const auto &font : std::as_const(fontList)) {
             if (fontCombo->findText(font) != -1)
                 continue;
 

--- a/src/widgets/dprintpreviewwidget.cpp
+++ b/src/widgets/dprintpreviewwidget.cpp
@@ -755,7 +755,7 @@ PrintOptions DPrintPreviewWidgetPrivate::printerOptions()
         if (pageRangeMode == DPrintPreviewWidget::CurrentPage) {
             pageRangeString = QString::number(pageRange.at(currentPageNumber - 1));
         } else {
-            Q_FOREACH (int pageRangeCount, pageRange) {
+            for (int pageRangeCount : std::as_const(pageRange)) {
                 pageRangeString.append(QString::number(pageRangeCount).append(","));
             }
 
@@ -957,7 +957,7 @@ void DPrintPreviewWidgetPrivate::calculateCurrentNumberPage()
         }
     }
 
-    Q_FOREACH (auto pageIndex, pageIndexVector) {
+    for (const auto &pageIndex : std::as_const(pageIndexVector)) {
         QPair<int, const QPicture *> picPair(pageIndex.first, pictures.at(pageIndex.second));
         numberUpPrintData->previewPictures.append(picPair);
     }

--- a/src/widgets/dsegmentedcontrol.cpp
+++ b/src/widgets/dsegmentedcontrol.cpp
@@ -215,7 +215,7 @@ int DSegmentedControl::indexByTitle(const QString &title) const
     D_DC(DSegmentedControl);
 
     int i=0;
-    Q_FOREACH (QToolButton *button, d->tabList) {
+    for (const auto *button : std::as_const(d->tabList)) {
         if(button->text() == title)
             return i;
         ++i;
@@ -278,7 +278,7 @@ int DSegmentedControl::addSegmented(const QIcon &icon, const QString &title)
  */
 void DSegmentedControl::addSegmented(const QStringList &titleList)
 {
-    Q_FOREACH (const QString &title, titleList) {
+    for (const auto &title : titleList) {
         addSegmented(title);
     }
 }
@@ -393,7 +393,7 @@ bool DSegmentedControl::setCurrentIndex(int currentIndex)
 
     d->currentIndex = currentIndex;
 
-    Q_FOREACH (QToolButton *button, d->tabList) {
+    for (auto *button : std::as_const(d->tabList)) {
         button->setEnabled(true);
     }
 

--- a/src/widgets/dshortcutedit.cpp
+++ b/src/widgets/dshortcutedit.cpp
@@ -135,24 +135,6 @@ bool DShortcutEdit::isValidShortcutKey(const QString &key)
             return false;
         }
 
-    /*const QStringList keys = key.split("+");
-
-    if (keys.size() == 1)
-    {
-        const QString firstKey = keys.first();
-        // F1 ~ F12
-        if (!firstKey.contains(QRegExp("^F(\\d|1[0-2])$")))
-            return false;
-    }
-
-    const QString lastKey = keys.last();
-    if (lastKey.size() == 2 && !lastKey.at(0).isLetter())
-        return false;
-    if (lastKey == "Meta" || lastKey == "Ctrl" ||
-        lastKey == "Shift" || lastKey == "Alt")
-        return false;*/
-
-
     qWarning() << "isValidShortcutKey: " << key;
     return true;
 }

--- a/src/widgets/dtitlebar.cpp
+++ b/src/widgets/dtitlebar.cpp
@@ -63,9 +63,9 @@ protected:
 private:
     void init();
     QWidget *targetWindow();
-    // FIXME: get a batter salution
+    // FIXME: get a better solution
     // hide title will make eventFilter not work, instead set Height to zero
-    bool isVisableOnFullscreen();
+    bool isVisibleOnFullscreen();
     void hideOnFullscreen();
     void showOnFullscreen();
 
@@ -375,7 +375,7 @@ QWidget *DTitlebarPrivate::targetWindow()
     return q->topLevelWidget()->window();
 }
 
-bool DTitlebarPrivate::isVisableOnFullscreen()
+bool DTitlebarPrivate::isVisibleOnFullscreen()
 {
     D_Q(DTitlebar);
     return !q->property("_restore_height").isValid();
@@ -1137,7 +1137,7 @@ bool DTitlebar::eventFilter(QObject *obj, QEvent *event)
             auto mouseEvent = reinterpret_cast<QMouseEvent *>(event);
             bool isFullscreen = d->targetWindow()->windowState().testFlag(Qt::WindowFullScreen);
             if (isFullscreen && d->autoHideOnFullscreen) {
-                if (mouseEvent->pos().y() > height() && d->isVisableOnFullscreen()) {
+                if (mouseEvent->pos().y() > height() && d->isVisibleOnFullscreen()) {
                     d->hideOnFullscreen();
                 }
                 if (mouseEvent->pos().y() < 2) {


### PR DESCRIPTION
…h range-based for

- dshortcutedit.cpp: remove dead commented-out code containing deprecated QRegExp
- dtitlebar.cpp: fix "batter salution" → "better solution", rename private method isVisableOnFullscreen → isVisibleOnFullscreen
- dapplication.cpp: fix "effoct" → "effect" in comment
- Replace Q_FOREACH with C++17 range-based for loops in: dblureffectwidget.cpp, dsegmentedcontrol.cpp, dcrumbedit.cpp, dexpandgroup.cpp, dprintpreviewdialog.cpp, ddrawergroup.cpp, dprintpreviewwidget.cpp

Log: Modernize deprecated Qt patterns and fix typos

Agent-Logs-Url: https://github.com/doniyor14/dtkwidget/sessions/b415c6ef-8e7c-4ed1-a3c1-e2c51b65763e