### PR TITLE
fix: prevent IME from activating when echo mode is Normal

### DIFF
--- a/src/widgets/dpasswordedit.cpp
+++ b/src/widgets/dpasswordedit.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2015 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2015 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -120,6 +120,21 @@ void DPasswordEdit::changeEvent(QEvent *event)
 
 bool DPasswordEdit::eventFilter(QObject* watcher, QEvent* event)
 {
+    // TODO: Qt6 QLineEdit 已实现 Qt::ImEnabled 查询项，返回 isEnabled() && !isReadOnly()，
+    // 导致 Qt::WA_InputMethodEnabled 设置失效。已向 Qt 上游提交修复，
+    // 若上游合入，此处的输入法事件拦截即可回退。
+    // 上游提交: https://codereview.qt-project.org/c/qt/qtbase/+/741207
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    if (watcher == lineEdit()) {
+        switch (event->type()) {
+        case QEvent::InputMethod:
+        case QEvent::InputMethodQuery:
+            return true;
+        default:
+            break;
+        }
+    }
+#endif
     return DLineEdit::eventFilter(watcher, event);
 }
 


### PR DESCRIPTION
1. Add event filter to intercept InputMethod and InputMethodQuery events on the line edit widget in Qt6
2. This works around a Qt6 bug where switching EchoMode to Normal invalidates WA_InputMethodEnabled and causes IME to reactivate
3. The filter is conditionally compiled only for Qt6 builds

Log: Fix IME reactivation issue in DPasswordEdit on Qt6 when password is visible

fix: 修复密码可见时输入法被意外激活的问题

1. 在 Qt6 构建中为 line edit 添加事件过滤器，拦截输入法相关事件
2. 解决 Qt6 切换 EchoMode 为 Normal 时 WA_InputMethodEnabled 失效 导致输入法被重新激活的问题
3. 该过滤仅在 Qt6 编译条件下生效

Log: 修复 Qt6 下 DPasswordEdit 密码可见时输入法被意外重新激活的问题
PMS: BUG-361783