### PR TITLE
fix(DMainWindow): parent DEnhancedWidget to DMainWindow to fix memory…

### DIFF
--- a/src/widgets/dmainwindow.cpp
+++ b/src/widgets/dmainwindow.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2017 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 

--- a/src/widgets/dmainwindow.cpp
+++ b/src/widgets/dmainwindow.cpp
@@ -186,7 +186,7 @@ DMainWindow::DMainWindow(QWidget *parent)
     }
 
     D_D(DMainWindow);
-    DEnhancedWidget *hanceedWidget = new DEnhancedWidget(d->titlebar, parent);
+    DEnhancedWidget *hanceedWidget = new DEnhancedWidget(d->titlebar, this);
     connect(hanceedWidget, &DEnhancedWidget::heightChanged, hanceedWidget, [d]() {
         d->updateTitleShadowGeometry();
     });


### PR DESCRIPTION
… leak

The DEnhancedWidget created in DMainWindow's constructor had the external `parent` parameter as its QObject parent. When DMainWindow is a top-level window (parent=nullptr), the DEnhancedWidget becomes orphaned with no Qt parent, causing a 512-byte memory leak on window close due to never being deleted.

Change the QObject parent from `parent` (constructor parameter) to `this` (the DMainWindow instance), ensuring the DEnhancedWidget is properly cleaned up when the main window is destroyed via Qt's parent-child auto-deletion mechanism.

Log: Fixed DEnhancedWidget memory leak by parenting to DMainWindow

Influence:
1. Verify DMainWindow normal creation and destruction, no crash on close
2. Verify titlebar shadow geometry updates still work after the change
3. Verify DMainWindow creation with non-null parent (child window scenario)
4. Run valgrind on dde-file-manager to confirm leak eliminated

fix(DMainWindow): 将 DEnhancedWidget 父对象改为 DMainWindow 修复内存泄露

DMainWindow 构造函数中创建的 DEnhancedWidget 使用了外部传入的
`parent` 参数作为 QObject 父对象。当 DMainWindow 作为顶层窗口
(parent=nullptr) 时，DEnhancedWidget 成为孤儿对象，窗口关闭后
因无 Qt parent 而无法自动释放，导致 512 字节内存泄露。

将 QObject 父对象从构造参数 `parent` 改为 `this`（DMainWindow
实例），确保 DEnhancedWidget 随主窗口销毁时通过 Qt 父子机制
自动清理。

Log: 修复 DEnhancedWidget 因父对象错误导致的内存泄露

Influence:
1. 验证 DMainWindow 正常创建与销毁，关闭窗口无崩溃
2. 验证标题栏阴影位置更新功能不受影响
3. 验证带非空 parent 的子窗口场景
4. 在 dde-file-manager 上运行 valgrind 确认泄露消除