### PR TITLE
fix: disable copy/cut and block undo/redo in DPasswordEdit

### DIFF
--- a/src/widgets/dpasswordedit.cpp
+++ b/src/widgets/dpasswordedit.cpp
@@ -14,7 +14,9 @@
 #include <QTimer>
 #include <QPushButton>
 #include <QLineEdit>
+#include <QMenu>
 #include <QKeyEvent>
+#include <QKeySequence>
 
 
 DWIDGET_BEGIN_NAMESPACE
@@ -42,6 +44,9 @@ DPasswordEdit::DPasswordEdit(QWidget *parent)
     D_D(DPasswordEdit);
 
     d->init();
+
+    setCopyEnabled(false);
+    setCutEnabled(false);
 }
 
 /*!
@@ -135,13 +140,49 @@ bool DPasswordEdit::eventFilter(QObject* watcher, QEvent* event)
         }
     }
 #endif
+
+    if (watcher == lineEdit() && event->type() == QEvent::KeyPress) {
+        QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
+        if (keyEvent->matches(QKeySequence::Undo)
+            || keyEvent->matches(QKeySequence::Redo)) {
+            return true;
+        }
+    }
+
+    if (watcher == lineEdit() && event->type() == QEvent::ContextMenu) {
+        QMenu *menu = lineEdit()->createStandardContextMenu();
+        if (!menu)
+            return DLineEdit::eventFilter(watcher, event);
+
+        for (QAction *action : menu->actions()) {
+            const auto &text = action->text();
+            if (text.startsWith(QLineEdit::tr("&Undo"))
+                || text.startsWith(QLineEdit::tr("&Redo"))) {
+                action->setEnabled(false);
+            }
+            if (text.startsWith(QLineEdit::tr("Cu&t")) && !cutEnabled()) {
+                action->setEnabled(false);
+            }
+            if (text.startsWith(QLineEdit::tr("&Copy")) && !copyEnabled()) {
+                action->setEnabled(false);
+            }
+            if (text.startsWith(QLineEdit::tr("&Paste")) && !pasteEnabled()) {
+                action->setEnabled(false);
+            }
+        }
+
+        menu->popup(static_cast<QContextMenuEvent *>(event)->globalPos());
+        event->accept();
+        lineEdit()->setFocus();
+        return true;
+    }
+
     return DLineEdit::eventFilter(watcher, event);
 }
 
 DPasswordEditPrivate::DPasswordEditPrivate(DPasswordEdit *q)
     : DLineEditPrivate(q)
 {
-
 }
 
 void DPasswordEditPrivate::init()

--- a/tests/testcases/widgets/ut_dpasswordedit.cpp
+++ b/tests/testcases/widgets/ut_dpasswordedit.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -38,6 +38,8 @@ TEST_F(ut_DPasswordEdit, setEchoMode)
 
 TEST_F(ut_DPasswordEdit, setCopyEnabled)
 {
+    ASSERT_FALSE(target->copyEnabled());
+
     target->setCopyEnabled(true);
     ASSERT_TRUE(target->copyEnabled());
 
@@ -47,10 +49,23 @@ TEST_F(ut_DPasswordEdit, setCopyEnabled)
 
 TEST_F(ut_DPasswordEdit, setCutEnabled)
 {
+    ASSERT_FALSE(target->cutEnabled());
+
     target->setCutEnabled(true);
     ASSERT_TRUE(target->cutEnabled());
 
     target->setCutEnabled(false);
     ASSERT_FALSE(target->cutEnabled());
+}
+
+TEST_F(ut_DPasswordEdit, setPasteEnabled)
+{
+    ASSERT_TRUE(target->pasteEnabled());
+
+    target->setPasteEnabled(true);
+    ASSERT_TRUE(target->pasteEnabled());
+
+    target->setPasteEnabled(false);
+    ASSERT_FALSE(target->pasteEnabled());
 }
 


### PR DESCRIPTION
DPasswordEdit构造时默认禁用复制、剪切功能，并拦截撤消、重做快捷键，防止密码信息泄露。

Log: DPasswordEdit禁用复制粘贴及撤销重做快捷操作
PMS: TASK-392179