### PR TITLE
tests: add source root to include paths

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -151,6 +151,7 @@ endif()
 
 target_include_directories(${BINNAME} PRIVATE
     ${PROJECT_SOURCE_DIR}/src/widgets
+    ${PROJECT_SOURCE_DIR}/src
     ${PROJECT_SOURCE_DIR}/include/DWidget
     ${PROJECT_SOURCE_DIR}/include/util
     ${PROJECT_SOURCE_DIR}/include/widgets


### PR DESCRIPTION
The test target compiles widget sources directly from the shared source list. Some of those sources include private util headers through paths such as "util/dprivateaccessor_p.h", but the target only adds src/widgets and the public include directories to its include search path.

Add the source root to the test target's private include paths so source-internal includes resolve the same way they do for the library target.

This fixes builds with tests enabled after the private accessor refactor.