### PR TITLE
fix: add null check for QDrag after exec in DTabBarPrivate::startDrag

### DIFF
--- a/src/widgets/dtabbar.cpp
+++ b/src/widgets/dtabbar.cpp
@@ -475,6 +475,11 @@ void DTabBarPrivate::startDrag()
 
     Q_EMIT q_func()->dragEnd(action);
 
+    // QDrag may be deleted by Qt's DnD framework during exec(),
+    // causing the QPointer to become null. Early-return to avoid SIGSEGV.
+    if (!drag)
+        return;
+
     if (action == Qt::IgnoreAction) {
         Q_EMIT q_func()->tabReleaseRequested(d->pressedIndex);
     } else if (drag->target() != this) {


### PR DESCRIPTION
QDrag may be deleted by Qt's DnD framework during exec(), causing
the QPointer to become null. Check drag before accessing it after
exec() returns to prevent SIGSEGV.

## Summary by Sourcery

Bug Fixes:
- Add a null check for QDrag after exec() in DTabBarPrivate::startDrag to avoid dereferencing a deleted drag object.