### PR TITLE
fix: restore soft keyboard input support in Qt6 for DLineEdit and DPasswordEdit

### DIFF
--- a/src/widgets/dlineedit.cpp
+++ b/src/widgets/dlineedit.cpp
@@ -23,6 +23,24 @@
 
 DWIDGET_BEGIN_NAMESPACE
 
+// TODO: Qt6 QLineEdit 已实现 Qt::ImEnabled 查询项，返回 isEnabled() && !isReadOnly()，
+// 导致 Qt::WA_InputMethodEnabled 设置失效。已向 Qt 上游提交修复，
+// 若上游合入，此处的输入法事件拦截即可回退。
+// 上游提交: https://codereview.qt-project.org/c/qt/qtbase/+/741207
+// 类似#746，支持阻止 IME 激活但不影响软键盘（软键盘通过 KeyEvent 路径输入）。
+class Q_DECL_HIDDEN DLineEditImpl : public QLineEdit
+{
+public:
+    using QLineEdit::QLineEdit;
+
+    QVariant inputMethodQuery(Qt::InputMethodQuery query) const override
+    {
+        if (query == Qt::ImEnabled)
+            return testAttribute(Qt::WA_InputMethodEnabled) && isEnabled() && !isReadOnly();
+        return QLineEdit::inputMethodQuery(query);
+    }
+};
+
 /*!
 @~english
   \class Dtk::Widget::DLineEdit
@@ -736,7 +754,7 @@ void DLineEditPrivate::init()
     Q_Q(DLineEdit);
 
     hLayout = new QHBoxLayout(q);
-    lineEdit = new QLineEdit(q);
+    lineEdit = new DLineEditImpl(q);
     q->setFocusProxy(lineEdit); // fix DlineEdit setFocut but lineEdit can not edit(without focus rect)
     q->setFocusPolicy(lineEdit->focusPolicy());
 

--- a/src/widgets/dpasswordedit.cpp
+++ b/src/widgets/dpasswordedit.cpp
@@ -125,22 +125,6 @@ void DPasswordEdit::changeEvent(QEvent *event)
 
 bool DPasswordEdit::eventFilter(QObject* watcher, QEvent* event)
 {
-    // TODO: Qt6 QLineEdit 已实现 Qt::ImEnabled 查询项，返回 isEnabled() && !isReadOnly()，
-    // 导致 Qt::WA_InputMethodEnabled 设置失效。已向 Qt 上游提交修复，
-    // 若上游合入，此处的输入法事件拦截即可回退。
-    // 上游提交: https://codereview.qt-project.org/c/qt/qtbase/+/741207
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    if (watcher == lineEdit()) {
-        switch (event->type()) {
-        case QEvent::InputMethod:
-        case QEvent::InputMethodQuery:
-            return true;
-        default:
-            break;
-        }
-    }
-#endif
-
     if (watcher == lineEdit() && event->type() == QEvent::KeyPress) {
         QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
         if (keyEvent->matches(QKeySequence::Undo)


### PR DESCRIPTION
The previous workaround for Qt6's ImEnabled behavior change
(Qt::WA_InputMethodEnabled not being respected) was too aggressive -
it blocked all input method events including those from soft keyboards,
which rely on InputMethod events for character input. This commit
replaces the broad event filter approach with a targeted override of
inputMethodQuery() in a custom DLineEditImpl class that correctly checks
the WA_InputMethodEnabled attribute. The password edit's event filter
for InputMethod events is removed since the base fix handles both cases.

Log: Fixed soft keyboard input being disabled in Qt6 for DLineEdit and
DPasswordEdit

Influence:
1. Test soft keyboard input (e.g., on-screen keyboard or touch keyboard)
works in DLineEdit
2. Test soft keyboard input works in DPasswordEdit
3. Verify that IME (Input Method Editor) can still be disabled via
WA_InputMethodEnabled attribute
4. Test normal keyboard input still functions correctly in both widgets
5. Verify that input method popup windows (e.g., text prediction) can be
disabled independently
6. Test in Qt6 environment specifically - ensure no regression for Qt5

fix: 在 Qt6 中恢复 DLineEdit 和 DPasswordEdit 的软键盘输入支持

之前的 Qt6 临时解决方案因过度拦截输入法事件导致软键盘输入被禁用。现通
过自定义 DLineEditImpl 类正确重写 inputMethodQuery() 方法替代全量事件过
滤，密码输入框也移除了相应的输入法事件拦截代码。

Log: 修复 DLineEdit 和 DPasswordEdit 在 Qt6 下软键盘输入被禁用的问题

Influence:
1. 测试 DLineEdit 中软键盘输入功能正常
2. 测试 DPasswordEdit 中软键盘输入功能正常
3. 验证通过 WA_InputMethodEnabled 属性仍可禁用输入法
4. 测试两个组件的普通键盘输入功能正常
5. 验证输入法弹窗（如文字预测）可独立禁用
6. 特别在 Qt6 环境下测试，确保 Qt5 无回归

PMS: BUG-371067
