### PR TITLE
fix: move Qt::Svg from public to private dependency

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,7 +71,6 @@ PUBLIC
     Qt${QT_VERSION_MAJOR}::Core
     Qt${QT_VERSION_MAJOR}::DBus
     Qt${QT_VERSION_MAJOR}::PrintSupport
-    Qt${QT_VERSION_MAJOR}::Svg
     Dtk${DTK_NAME_SUFFIX}::Gui
     Dtk${DTK_NAME_SUFFIX}::Core
 PRIVATE
@@ -79,6 +78,7 @@ PRIVATE
     Qt${QT_VERSION_MAJOR}::GuiPrivate
     Qt${QT_VERSION_MAJOR}::WidgetsPrivate
     Qt${QT_VERSION_MAJOR}::PrintSupportPrivate
+    Qt${QT_VERSION_MAJOR}::Svg
 )
 if(LINUX)
   target_link_libraries(${LIB_NAME}


### PR DESCRIPTION
The Qt::Svg module was incorrectly listed as a public dependency
in dtkwidget's CMakeLists.txt, causing unnecessary propagation to
downstream projects. This change moves it to private dependencies to
prevent transitive exposure and resolve CMake configuration failures in
applications depending on dtkwidget.

Log: Fix cmake error caused by exposed QtSvg dependency

Influence:
1. Verify cmake configuration of dtkwidget-dependent projects
2. Test build without Qt::Svg header includes in public interface
3. Confirm no regression in applications using dtk widgets with SVG
functionality
4. Verify the fix with clean build environments

fix: 将Qt::Svg从公共依赖移至私有依赖

Qt::Svg模块错误地被列为dtkwidget的公共依赖，导致下游项目继承该依赖并出现
cmake配置失败。本次修改将其移至私有依赖区域，避免依赖传递暴露。

Log: 修复QtSvg依赖暴露导致的cmake错误

Influence:
1. 验证依赖dtkwidget的项目的cmake配置是否正常
2. 测试在公共接口中不包含Qt::Svg头文件的构建
3. 确认使用dtk窗口组件SVG功能的应用程序无回归
4. 在全新构建环境中验证修复效果

## Summary by Sourcery

Bug Fixes:
- Resolve CMake configuration errors caused by Qt Svg being exposed as a public dependency of dtkwidget.