### PR TITLE
fix(ddialog): reject on close to avoid accepted()

### DIFF
--- a/src/widgets/ddialog.cpp
+++ b/src/widgets/ddialog.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2017 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -1158,7 +1158,7 @@ void DDialog::closeEvent(QCloseEvent *event)
 
     Q_EMIT aboutToClose();
 
-    done(d->clickedButtonIndex);
+    reject();
 
     Q_EMIT visibleChanged(isVisible());
     Q_EMIT closed();


### PR DESCRIPTION
1. Window close (X button) now calls reject() instead of done(clickedButtonIndex)
2. Stale button index was misinterpreted as DialogCode, so closing after Confirm emitted accepted() and sent the old password to the auth session
3. Behavior now matches QDialog::closeEvent: closing the window always means rejection
4. Cancel button and ESC key paths are unaffected

Log: Window close now always rejects, fixing false accepted() from the stale button index
Influence: X close now rejects, no more false accepted()

fix(ddialog): 关闭窗口时始终拒绝，避免误触发 accepted()

1. X 关闭时改为调用 reject()，不再用残留的按钮索引
2. 修复先点确认再点 X 关闭时误触发 accepted()、把旧密码发送给认证会话的问题
3. 与 QDialog::closeEvent 语义一致：关闭窗口即拒绝
4. Cancel 按钮与 ESC 键路径不受影响

Log: 窗口关闭（X 按钮）始终走 reject，修复残留按钮索引误触发 accepted() 的问题
PMS: BUG-371549
Influence: 修复鉴权框点 X 关闭误发密码、误触发 accepted() 的问题

## Summary by Sourcery

Bug Fixes:
- Fix dialog close via the window X button incorrectly emitting accepted() due to a stale clicked button index.