### PR TITLE
fix: update dialog size after resize event with fractional scaling

### DIFF
--- a/src/widgets/dabstractdialog.cpp
+++ b/src/widgets/dabstractdialog.cpp
@@ -407,6 +407,11 @@ void DAbstractDialog::showEvent(QShowEvent *event)
         setDisplayPosition(displayPosition());
     }
 
+    // A derived dialog can adjust its size during the initial show without
+    // receiving another resize event, so synchronize the blur widget here.
+    if (d->bgBlurWidget)
+        d->bgBlurWidget->resize(size());
+
     QDialog::showEvent(event);
 }
 

--- a/src/widgets/ddialog.cpp
+++ b/src/widgets/ddialog.cpp
@@ -1179,7 +1179,17 @@ void DDialog::childEvent(QChildEvent *event)
 
 void DDialog::resizeEvent(QResizeEvent *event)
 {
-    return DAbstractDialog::resizeEvent(event);
+    D_D(DDialog);
+    const bool shouldUpdateSize = !testAttribute(Qt::WA_Resized)
+            && event->size().width() != event->oldSize().width();
+
+    DAbstractDialog::resizeEvent(event);
+
+    // With a fractional scale factor, the platform may report a logical width
+    // that differs by one pixel from the requested width. Recalculate the
+    // height using that final width so word-wrapped text is not clipped.
+    if (shouldUpdateSize)
+        d->updateSize();
 }
 
 void DDialog::keyPressEvent(QKeyEvent *event)


### PR DESCRIPTION
1. Added a resize call for the background blur widget in
`DAbstractDialog::showEvent` to ensure proper synchronization when
a derived dialog adjusts its size during the initial show without
receiving another resize event
2. Modified `DDialog::resizeEvent` to recalculate the dialog size when
the platform reports a logical width differing by one pixel from the
requested width due to fractional scale factors
3. Added conditional check using `WA_Resized` attribute and width
comparison to avoid unnecessary size recalculations
4. Recalculated height after resize to prevent word-wrapped text from
being clipped

Log: Fixed dialog display issue with fractional scaling where text could
appear clipped

Influence:
1. Test dialog display at fractional scale factors (e.g., 125%, 150%) on
Windows, verifying text is not clipped
2. Test dialogs with word-wrapped text content at various window sizes
3. Verify the background blur effect aligns correctly when dialogs are
resized
4. Test derived dialog classes that adjust their size during the initial
show
5. Verify no unexpected layout jumps or flickering during resize
operations

fix: 修复小数缩放比例下对话框尺寸更新问题

1. 在 `DAbstractDialog::showEvent` 中添加了背景模糊控件的尺寸同步，确保
派生对话框在初始显示时调整大小后能够正确匹配
2. 修改了 `DDialog::resizeEvent`，当平台因小数缩放比例导致逻辑宽度与请求
宽度相差一个像素时，重新计算对话框尺寸
3. 添加了基于 `WA_Resized` 属性和宽度比较的条件判断，避免不必要的尺寸
重算
4. 在缩放后重新计算高度，防止文本换行显示时被裁剪

Log: 修复小数缩放比例下对话框文本显示被裁剪的问题

Influence:
1. 在 Windows 系统上测试 125%、150% 等小数缩放比例下对话框的显示，验证文
本是否完整
2. 测试不同窗口大小下包含换行文本内容的对话框
3. 验证对话框尺寸调整时背景模糊效果是否对齐
4. 测试在初始显示时调整自身尺寸的派生对话框类
5. 验证缩放过程中没有意外的布局跳动或闪烁

PMS: BUG-370643

## Summary by Sourcery

Improve dialog size handling under fractional display scaling to prevent clipped content and keep visual effects in sync.

Bug Fixes:
- Ensure word-wrapped dialog text is not clipped when the platform reports a slightly different logical width under fractional scale factors.
- Synchronize the background blur widget size when derived dialogs adjust their dimensions on initial show without a subsequent resize event.

Enhancements:
- Avoid unnecessary dialog size recalculations by checking resize state and width changes before updating layout.