### PR TITLE
fix: correct option button hover state after popup menu closes

### DIFF
--- a/src/widgets/dtitlebar.cpp
+++ b/src/widgets/dtitlebar.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2017 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -73,6 +73,7 @@ private:
     void updateButtonsState(Qt::WindowFlags type);
     void updateButtonsFunc();
     void updateCenterArea();
+    void updateOptionButtonHoverState();
 
     void handleParentWindowStateChange();
     void handleParentWindowIdChange();
@@ -375,6 +376,22 @@ QWidget *DTitlebarPrivate::targetWindow()
     return q->topLevelWidget()->window();
 }
 
+void DTitlebarPrivate::updateOptionButtonHoverState()
+{
+    if (!optionButton || !optionButton->underMouse())
+        return;
+
+    // Closing a popup while the option button is pressed may prevent
+    // QWidget from receiving the mouse leave event. Check the real cursor
+    // position before correcting the stale under-mouse state.
+    const QPoint cursorPos = optionButton->mapFromGlobal(QCursor::pos());
+    if (optionButton->rect().contains(cursorPos))
+        return;
+
+    optionButton->setAttribute(Qt::WA_UnderMouse, false);
+    optionButton->update();
+}
+
 bool DTitlebarPrivate::isVisableOnFullscreen()
 {
     D_Q(DTitlebar);
@@ -550,6 +567,11 @@ void DTitlebarPrivate::handleParentWindowIdChange()
 {
     if (!targetWindowHandle) {
         targetWindowHandle = targetWindow()->windowHandle();
+        D_Q(DTitlebar);
+        // After a popup mouse grab, the release event is delivered to the
+        // QWidget's backing QWindow (QWidgetWindow), rather than the QWidget.
+        // Filter only this window handle instead of the whole application.
+        targetWindowHandle->installEventFilter(q);
 
         updateButtonsFunc();
     } else if (targetWindow()->windowHandle() != targetWindowHandle) {
@@ -1175,6 +1197,21 @@ bool DTitlebar::eventFilter(QObject *obj, QEvent *event)
             break;
 
         }
+    } else if (obj == d->targetWindowHandle) {
+        switch (event->type()) {
+        case QEvent::MouseButtonRelease: {
+            const auto mouseEvent = static_cast<QMouseEvent *>(event);
+            // Reconcile the option button's hover state after the popup mouse
+            // grab ends and the left button is released on the backing window.
+            if (mouseEvent->button() == Qt::LeftButton) {
+                d->updateOptionButtonHoverState();
+            }
+            break;
+        }
+        default:
+            break;
+        }
+
     }
     if (d->titlebarSettings && d->titlebarSettingsImpl->hasEditPanel() && obj == d->titlebarSettingsImpl->toolsEditPanel()) {
         if (event->type() == QEvent::Show) {


### PR DESCRIPTION
Clear stale hover state on the option (More) button when the mouse is
no longer over it, which previously stuck after the popup menu grabbed
the mouse and closed without delivering a proper leave event.

The fix installs an event filter on the QWidget's backing window handle
instead of the whole application. When a popup grabs the mouse, the
release event is delivered to the QWidgetWindow rather than the QWidget
itself. On left-button release, the real cursor position is checked and
the WA_UnderMouse attribute is cleared if the cursor has moved outside
the button's bounds.

Log: Fixed the More button remaining in hover state after dragging away
from it following popup menu close

Influence:
1. Open the More menu, drag out of the button area, and release - verify
the button exits hover state
2. Open the More menu and click inside the menu - verify the button
hover state is correct
3. Open the More menu and press Escape - verify the button hover state
is cleared
4. Use keyboard navigation to open and close the menu multiple times -
verify no stale hover states
5. Test with different window states (normal, maximized, fullscreen) to
ensure consistent behavior

fix: 修复弹出菜单关闭后更多按钮悬停状态不正确的问题

在弹出菜单捕获鼠标并关闭后，未正确传递鼠标离开事件，导致更多按钮在鼠标不
再悬停于其上时仍保持悬停状态。本修复通过清除陈旧的悬停状态来解决此问题。

修复方案是在 QWidget 的后台窗口句柄上安装事件过滤器，而不是在整个应用程
序上。当弹出菜单捕获鼠标时，释放事件会传递到 QWidgetWindow 而非 QWidget
本身。在左键释放时，会检查实际光标位置，如果光标已移出按钮边界，则清除
WA_UnderMouse 属性。

Log: 修复弹出菜单后拖拽移出按钮区域时更多按钮仍保持悬停状态的问题

Influence:
1. 打开更多菜单，拖拽移出按钮区域并释放 - 验证按钮退出悬停状态
2. 打开更多菜单并在菜单内点击 - 验证按钮悬停状态正确
3. 打开更多菜单并按 Escape 键 - 验证按钮悬停状态被清除
4. 使用键盘导航多次打开和关闭菜单 - 验证无陈旧的悬停状态
5. 在窗口不同状态（普通、最大化、全屏）下测试，确保行为一致

PMS: BUG-336505

## Summary by Sourcery

Ensure the titlebar option (More) button correctly clears its hover state after popup menus close and mouse grabs end.

Bug Fixes:
- Clear stale hover state on the titlebar option button when a popup menu closes after grabbing the mouse and the cursor has moved away from the button.

Enhancements:
- Install an event filter on the titlebar widget's backing window handle to reconcile the option button hover state on mouse release events.
- Add a helper to recompute the option button hover state based on the actual cursor position after popup interactions.

Chores:
- Update SPDX copyright years in the titlebar implementation file to include 2026.