### PR TITLE
fix: correct scroll button enabled state after lazy layoutTabs in DTabBar

### DIFF
--- a/src/widgets/dtabbar.cpp
+++ b/src/widgets/dtabbar.cpp
@@ -1589,6 +1589,10 @@ void DTabBarPrivate::tabLayoutChange()
     q->tabLayoutChange();
     // 更新关闭按钮的显示
     updateCloseButtonVisible();
+    // 修正滚动按钮的启用状态：layoutTabs() 会将 leftB 重置为 disabled，
+    // 需根据实际 scrollOffset 重新计算，修复惰性布局路径（如 paintEvent
+    // 中经 tabRect() 触发的 layoutTabs）下左右滚动按钮 enabled 状态反转的问题。
+    makeVisible(currentIndex());
 }
 
 void DTabBarPrivate::initStyleOption(QStyleOptionTab *option, int tabIndex) const


### PR DESCRIPTION
## 根因分析

窗口缩至最小、多 tab 溢出时，DTabBar 左右滚动按钮可点击状态反转：左侧 disabled（实际最左 tab 已隐藏，应可点），右侧 enabled（最右 tab 已可见，应不可点）。

**根因**：Qt `QTabBarPrivate::layoutTabs()` 硬编码 `leftB->setEnabled(false)`，`makeVisible()` 才根据实际 `scrollOffset` 修正为正确状态。`layoutTabs()` 存在惰性调用路径（经 `tabRect()` 在 `paintEvent` 中触发），该路径不调用 `makeVisible()`。DTK 的 `DTabBar::resizeEvent` 不触发 QTabBar 子部件的 `makeVisible`，而文管 `TabBar::resizeEvent` 的 `setIconSize(iconSize())` 临时方案会设置 `layoutDirty=true` 触发惰性 `layoutTabs`，导致按钮状态被重置为默认值且无人修正。

## 修复方案

在 `DTabBarPrivate::tabLayoutChange()`（`layoutTabs()` 末尾调用的虚函数）中增加 `makeVisible(currentIndex())` 调用，确保每次 `layoutTabs()` 完成后（包括惰性路径）滚动按钮的 enabled 状态根据实际 `scrollOffset` 修正。

## 改动安全评估

低风险：不修改函数签名，不删除公开函数，仅增加一行对已有方法 `makeVisible` 的调用（该方法已在 `startMove`、`startTabFlash` 等处使用）。`makeVisible` 内部有 `validIndex` 守卫，无递归风险。

## Summary by Sourcery

Bug Fixes:
- Fix left/right scroll button enabled state being inverted after lazy layoutTabs execution by recalculating visibility based on the current tab index.