### PR TITLE
fix: wheel event not propagating to parent in Qt6

### DIFF
--- a/include/widgets/dcombobox.h
+++ b/include/widgets/dcombobox.h
@@ -23,6 +23,8 @@ public:
 protected:
     DComboBox(DComboBoxPrivate &dd, QWidget *parent);
 
+    void wheelEvent(QWheelEvent *event) override;
+
     // QComboBox interface
 public:
     virtual void showPopup() override;

--- a/include/widgets/dslider.h
+++ b/include/widgets/dslider.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2011 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2011 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 

--- a/include/widgets/dspinbox.h
+++ b/include/widgets/dspinbox.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2015 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2015 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -25,6 +25,10 @@ class LIBDTKWIDGETSHARED_EXPORT DSpinBox : public QSpinBox, public DTK_CORE_NAME
 public:
     explicit DSpinBox(QWidget *parent = nullptr);
 
+protected:
+    void wheelEvent(QWheelEvent *event) override;
+
+public:
     QLineEdit *lineEdit() const;
 
     bool isAlert() const;
@@ -65,6 +69,10 @@ class LIBDTKWIDGETSHARED_EXPORT DDoubleSpinBox : public QDoubleSpinBox, public D
 public:
     explicit DDoubleSpinBox(QWidget *parent = nullptr);
 
+protected:
+    void wheelEvent(QWheelEvent *event) override;
+
+public:
     bool isAlert() const;
     void showAlertMessage(const QString &text, int duration = 3000);
     void showAlertMessage(const QString &text, QWidget *follower, int duration = 3000);

--- a/src/widgets/dcombobox.cpp
+++ b/src/widgets/dcombobox.cpp
@@ -32,6 +32,7 @@
 #include <QScreen>
 #include <QStack>
 #include <QWindow>
+#include <QWheelEvent>
 
 DWIDGET_BEGIN_NAMESPACE
 
@@ -109,6 +110,7 @@ DComboBox::DComboBox(QWidget *parent)
 {
     D_D(DComboBox);
     d->init();
+    setFocusPolicy(Qt::StrongFocus);
 }
 
 DComboBox::DComboBox(DComboBoxPrivate &dd, QWidget *parent)
@@ -117,6 +119,16 @@ DComboBox::DComboBox(DComboBoxPrivate &dd, QWidget *parent)
 {
     D_D(DComboBox);
     d->init();
+    setFocusPolicy(Qt::StrongFocus);
+}
+
+void DComboBox::wheelEvent(QWheelEvent *event)
+{
+    if (hasFocus()) {
+        QComboBox::wheelEvent(event);
+    } else {
+        QWidget::wheelEvent(event);
+    }
 }
 
 /*!

--- a/src/widgets/dslider.cpp
+++ b/src/widgets/dslider.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2011 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2011 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -136,7 +136,11 @@ bool DSlider::eventFilter(QObject *watched, QEvent *e)
     Q_D(DSlider);
 
     if ((watched == d->slider) && (e->type() == QEvent::Wheel)) {
-        return !d->mouseWheelEnabled;
+        if (d->mouseWheelEnabled && d->slider->hasFocus()) {
+            return false;  // let QSlider::wheelEvent handle it (stepBy + accept)
+        }
+        e->ignore();  // Qt6: un-accept so event propagates to parent (e.g. scrollarea)
+        return true;   // block delivery to the inner QSlider
     }
 
     if (e->type() == QEvent::MouseButtonRelease) {

--- a/src/widgets/dspinbox.cpp
+++ b/src/widgets/dspinbox.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2015 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2015 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -7,6 +7,8 @@
 #include "dspinbox.h"
 #include "private/dspinbox_p.h"
 #include "dlineedit.h"
+
+#include <QWheelEvent>
 
 DWIDGET_BEGIN_NAMESPACE
 
@@ -63,6 +65,16 @@ DSpinBox::DSpinBox(QWidget *parent) :
     DObject(*new DSpinBoxPrivate(this))
 {
     d_func()->init();
+    setFocusPolicy(Qt::StrongFocus);
+}
+
+void DSpinBox::wheelEvent(QWheelEvent *event)
+{
+    if (hasFocus()) {
+        QSpinBox::wheelEvent(event);
+    } else {
+        QWidget::wheelEvent(event);
+    }
 }
 
 /*!
@@ -180,6 +192,16 @@ DDoubleSpinBox::DDoubleSpinBox(QWidget *parent) :
     DObject(*new DDoubleSpinBoxPrivate(this))
 {
     d_func()->init();
+    setFocusPolicy(Qt::StrongFocus);
+}
+
+void DDoubleSpinBox::wheelEvent(QWheelEvent *event)
+{
+    if (hasFocus()) {
+        QDoubleSpinBox::wheelEvent(event);
+    } else {
+        QWidget::wheelEvent(event);
+    }
 }
 
 bool DDoubleSpinBox::isAlert() const


### PR DESCRIPTION
## 背景 / Background

Qt6 的 `QApplication::notify` 在派发 wheel event 前执行 `we.setAccepted(true)`。若控件的 `wheelEvent` 不调用父类事件函数（最终 `event->ignore()`），事件将保持 accepted 状态，不会向父控件（如 `QScrollArea`）传播——这与 Qt5 行为不一致（Qt5 中未处理的滚轮事件默认可传播）。

导致所有 dtk6widget 应用中，位于 `QScrollArea` / `DScrollArea` 内的 `DSpinBox` / `DDoubleSpinBox` / `DComboBox` / `DSlider` 在鼠标悬停滚动时会阻断页面滚动（值被误改 / 选项被切换，但页面不滚动）。复现场景：打印预览高级设置、设置对话框、`examples/collections` 示例等。

## 根因 / Root Cause

- `DSpinBox`（继承 `QSpinBox`）、`DDoubleSpinBox`（继承 `QDoubleSpinBox`）、`DComboBox`（继承 `QComboBox`）均未重写 `wheelEvent`，沿用各自基类的 `wheelEvent`（调用 `stepBy()` / 切项 + `event->accept()`），在 Qt6 下事件被 accept 后不传播。
- `DSlider` 继承结构不同：继承 `QWidget`，内部持有 `SpecialSlider : public QSlider`，并通过 `qApp->installEventFilter` 拦截内部 slider 的滚轮事件，原逻辑在 Qt6 下同样阻断传播。
- 参考既有修复 [fe16c8e9](https://github.com/linuxdeepin/dtkwidget/commit/fe16c8e9dcae482f5105673c95217dedf5b06cb3)（`settings/ComboBox::wheelEvent`）：有焦点时调基类 `wheelEvent`，无焦点时 `return QWidget::wheelEvent(e)`（即 `ignore()`）让事件传播。

## 改动 / Changes

沿用 `fe16c8e9` 的成熟模式，对 4 个控件统一修复（共 5 个文件）：

1. **`DSpinBox` / `DDoubleSpinBox`**（`include/widgets/dspinbox.h` + `src/widgets/dspinbox.cpp`）
   - 重写 `wheelEvent`：有焦点 → 调 `QSpinBox` / `QDoubleSpinBox::wheelEvent`（保留滚轮调值）；无焦点 → `QWidget::wheelEvent`（`ignore()` 传播给 scrollarea）。

2. **`DComboBox`**（`include/widgets/dcombobox.h` + `src/widgets/dcombobox.cpp`）
   - 重写 `wheelEvent`：有焦点 → 调 `QComboBox::wheelEvent`（保留滚轮切项）；无焦点 → `QWidget::wheelEvent`（传播）。

3. **`DSlider`**（`src/widgets/dslider.cpp`）
   - 因继承结构不同，在其 `eventFilter` 中处理：内部 slider 无焦点时 `e->ignore()` + `return true`，在 Qt6 下取消 accept 使事件传播给父控件，等价于 `fe16c8e9` 模式。

## 行为 / Behavior

| 控件 | 焦点 | 修改前（Qt6） | 修改后 |
|---|---|---|---|
| spinbox / combobox / slider | 无 | 阻断滚动 ❌ | 页面滚动 ✅ |
| spinbox / combobox / slider | 有 | 调值 / 切项 | 调值 / 切项（不变） |

- 恢复 Qt5 行为：鼠标悬停无焦点时滚轮滚动页面；点击聚焦后滚轮调值 / 切项。
- `readOnly` spinbox 聚焦后滚动：基类自身 `ignore()`，事件正常传播，无需额外判断。
- `DLineEdit` / `DFileChooserEdit` 不受影响（`QLineEdit` 不重写 `wheelEvent`，默认 `ignore()`），未改动。
- Qt5 / Qt6 跨版本兼容：仅用公开 API，无 `#if` 条件编译。对 Qt5 无影响（本就正常），修复 Qt6 回归。

## 自测 / Test

- 编译验证（DTK6 / Qt6）：`dspinbox.cpp` / `dcombobox.cpp` / `dslider.cpp` 均编译通过，零 error / warning。
- 待带界面测试机验证：
  1. `examples/collections` 中 spinbox / combobox / slider 在 scrollarea 内 → 无焦点滚轮滚动页面，有焦点滚轮调值 / 切项。
  2. 打印预览 Ctrl+P → 展开高级设置 → 滚轮经过页边距 / 缩放 / 份数 / 水印等控件时页面正常滚动。
  3. 点击控件聚焦后滚轮 → 保留原有行为（无回归）。

## 关联 / References

- Multica: [DDE-72](https://agent-dev.uniontech.com/dde/issues/26b4aeaf-7c2f-4ea8-a31c-9e5f66169bcd)
- PMS: https://pms.uniontech.com/bug-view-339039.html
- 参考提交: https://github.com/linuxdeepin/dtkwidget/commit/fe16c8e9dcae482f5105673c95217dedf5b06cb3

> ⚠️ Draft PR，待审核，请勿合并。

## Summary by Sourcery

Restore expected wheel scrolling behavior for DTK input widgets nested in scroll areas without changing focused-widget interactions.

Bug Fixes:
- Restore wheel-event propagation from unfocused spin boxes, combo boxes, and sliders to parent scroll areas under Qt6 while preserving value adjustment or item selection when focused.

Enhancements:
- Align widget focus behavior with Qt5 expectations across supported Qt versions.