### PR TITLE
fix: apply selected paper size after printer settings rebuild

### DIFF
--- a/src/widgets/dprintpreviewdialog.cpp
+++ b/src/widgets/dprintpreviewdialog.cpp
@@ -1803,6 +1803,9 @@ void DPrintPreviewDialogPrivate::_q_printerChanged(int index)
         }
     }
 
+    // The current index may not change when the paper list is rebuilt, so the
+    // combo-box signal is not guaranteed to apply the selected page size.
+    matchFitablePageSize();
     marginsUpdate(true);
     paperSizeCombo->blockSignals(false);
     if (isInited)

--- a/tests/testcases/printpreview/ut_dprintpreviewdialog.cpp
+++ b/tests/testcases/printpreview/ut_dprintpreviewdialog.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -336,6 +336,21 @@ TEST_F(ut_DPrintPreviewDialog, testPrintDeviceCombo)
 
     ASSERT_STREQ(test_dialog_d->printDeviceCombo->currentText().toLocal8Bit(), "Print to PDF");
     ASSERT_STREQ(test_dialog_d->pageRangeCombo->currentText().toLocal8Bit(), "All");
+}
+
+TEST_F(ut_DPrintPreviewDialog, testPaperSizeAppliedAfterPrinterChanged)
+{
+    test_dialog_d->paperSizeCombo->setCurrentText("8K");
+    ASSERT_EQ(test_dialog_d->printer->pageSize(), QPrinter::Custom);
+
+    // Rebuild the paper-size list while preserving the selected custom size.
+    // This path blocks the combo-box signal, so the page size must be applied
+    // explicitly after the selection is restored.
+    test_dialog_d->printer->setPageSize(QPageSize::A4);
+    test_dialog_d->_q_printerChanged(test_dialog_d->printDeviceCombo->currentIndex());
+
+    ASSERT_STREQ(test_dialog_d->paperSizeCombo->currentText().toLocal8Bit(), "8K");
+    ASSERT_EQ(test_dialog_d->printer->pageSize(), QPrinter::Custom);
 }
 
 TEST_F(ut_DPrintPreviewDialog, testCancelBtn)


### PR DESCRIPTION
## Summary

- explicitly apply the selected paper size after rebuilding printer settings
- keep the preview and printer page layout consistent when the default item is a custom paper size
- add a regression test for restoring a custom paper-size selection

## Tests

- `cmake --build build -j6 --target ut-dtkwidget`
- print-preview regression test: passed
- `cmake --build build6 -j6 --target dtk6widget`

## Summary by Sourcery

Preserve the selected paper size when rebuilding printer settings.

Bug Fixes:
- Ensure the selected custom paper size is reapplied after printer settings rebuilds so the preview and printer page layout remain consistent.

Tests:
- Add a regression test covering restoration of a custom paper-size selection after changing printers.