### PR TITLE
fix: cache printer names to avoid repeated queries

### DIFF
--- a/src/widgets/dprintpreviewdialog.cpp
+++ b/src/widgets/dprintpreviewdialog.cpp
@@ -1017,7 +1017,7 @@ void DPrintPreviewDialogPrivate::initdata()
 {
     Q_Q(DPrintPreviewDialog);
     QStringList itemlist;
-    itemlist << QPrinterInfo::availablePrinterNames()
+    itemlist << availablePrinterNames()
              << qApp->translate("DPrintPreviewDialogPrivate", "Print to PDF")
              << qApp->translate("DPrintPreviewDialogPrivate", "Save as Image");
     printDeviceCombo->addItems(itemlist);
@@ -1294,6 +1294,12 @@ void DPrintPreviewDialogPrivate::initconnections()
     QObject::connect(copycountspinbox->lineEdit(), SIGNAL(textEdited(const QString &)), q, SLOT(_q_spinboxValueEmptyChecked(const QString &)));
     QObject::connect(scaleRateEdit->lineEdit(), SIGNAL(textEdited(const QString &)), q, SLOT(_q_spinboxValueEmptyChecked(const QString &)));
     QObject::connect(inclinatBox->lineEdit(), SIGNAL(textEdited(const QString &)), q, SLOT(_q_spinboxValueEmptyChecked(const QString &)));
+
+    QObject::connect(q, &DPrintPreviewDialog::finished, q, [this]() {
+        qDebug(dPrintPreview) << "DPrintPreviewDialog finished, clear printerNames";
+        printerNames.clear();
+        printerNamesInited = false;
+    });
 }
 
 void DPrintPreviewDialogPrivate::setfrmaeback(DFrame *frame)
@@ -2253,10 +2259,20 @@ void DPrintPreviewDialogPrivate::matchFitablePageSize()
     }
 }
 
+QStringList DPrintPreviewDialogPrivate::availablePrinterNames()
+{
+    if (!printerNamesInited) {
+        qDebug(dPrintPreview) << "Get printer names from QPrinterInfo.";
+        printerNamesInited = true;
+        printerNames = QPrinterInfo::availablePrinterNames();
+        qDebug(dPrintPreview) << "Available printer names:" << printerNames;
+    }
+    return printerNames;
+}
+
 bool DPrintPreviewDialogPrivate::isActualPrinter(const QString &name)
 {
-    const QStringList &printerNames = QPrinterInfo::availablePrinterNames();
-    return printerNames.contains(name);
+    return availablePrinterNames().contains(name);
 }
 
 QString DPrintPreviewDialogPrivate::getColorModeConfig(const QString &printer)

--- a/src/widgets/private/dprintpreviewdialog_p.h
+++ b/src/widgets/private/dprintpreviewdialog_p.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -92,6 +92,7 @@ public:
     void setPageLayoutEnable(const bool &checked);
     void matchFitablePageSize();
     bool isActualPrinter(const QString &name);
+    QStringList availablePrinterNames();
     QString getColorModeConfig(const QString &printer);
     void saveColorModeConfig(const QString &printer, const QString &colorMode);
 
@@ -189,6 +190,8 @@ public:
     DSpinBox *opaBox = nullptr;
     QVector<qreal> marginOldValue; // 记录margin自定义时的旧值  如果旧值和新值一致，就不需要刷新，top left right bottom
     QList<qreal> minnumMargins;
+    QStringList printerNames;
+    bool printerNamesInited = false;
     QSpacerItem *spacer = nullptr;
     QSpacerItem *wmSpacer = nullptr;
     DFloatingWidget *colorWidget = nullptr;


### PR DESCRIPTION
fix: cache printer names to improve print preview performance

1. Add a cached `availablePrinterNames()` method that stores printer
names in `printerNames` member variable
2. Initialize the cache lazily with `printerNamesInited` flag to avoid
repeated expensive calls to `QPrinterInfo::availablePrinterNames()`
3. Clear the printer name cache when the dialog is finished, ensuring
fresh data on next dialog opening
4. Replace direct calls to `QPrinterInfo::availablePrinterNames()` in
`initdata()` and `isActualPrinter()` with the cached method
5. Fix copyright year in header from 2022 to 2026
6. Add debug logging for cache initialization and cleanup

Log: Optimized print preview performance by caching printer names

Influence:
1. Verify printer list displays correctly in the print preview dialog
2. Test opening and closing the print preview dialog multiple times to
confirm printer names refresh properly
3. Test with system printers added/removed while dialog is open to
verify cache behavior
4. Verify "Print to PDF" and "Save as Image" options still appear in
the list
5. Test print functionality with both actual printers and virtual
printers

fix: 缓存打印机名称以提升打印预览性能

1. 新增 `availablePrinterNames()` 方法，将打印机名称缓存在
`printerNames` 成员变量中
2. 使用 `printerNamesInited` 标志实现惰性初始化，避免重复调用昂贵的
`QPrinterInfo::availablePrinterNames()` 接口
3. 在对话框关闭时清空打印机名称缓存，确保下次打开时获取最新数据
4. 将 `initdata()` 和 `isActualPrinter()` 中的直接调用替换为缓存方法
5. 修正头文件版权年份从 2022 到 2026
6. 添加缓存初始化和清理的调试日志

Log: 通过缓存打印机名称优化打印预览性能

Influence:
1. 验证打印预览对话框中打印机列表显示正常
2. 测试多次打开和关闭打印预览对话框，确认打印机名称能正确刷新
3. 测试在对话框打开期间添加或移除系统打印机，验证缓存行为
4. 验证"打印到 PDF"和"保存为图片"选项仍正常显示在列表中
5. 测试使用真实打印机和虚拟打印机的打印功能


PMS: BUG-375053

## Summary by Sourcery

Cache available printer names during print preview sessions to reduce repeated system printer queries while preserving fresh printer data between sessions.

Bug Fixes:
- Refresh printer discovery when the print preview dialog is reopened while avoiding repeated queries during a dialog session.

Enhancements:
- Improve print preview performance by caching available printer names for the lifetime of the dialog and reusing them for printer validation.

Chores:
- Update the dialog header copyright year.