### PR TITLE
feat(DrawUtils): add drawInsetShadow for inner shadow rendering

### DIFF
--- a/include/widgets/dstyle.h
+++ b/include/widgets/dstyle.h
@@ -45,6 +45,7 @@ Q_DECLARE_FLAGS(Corners, Corner)
 
 void drawShadow(QPainter *pa, const QRect &rect, qreal xRadius, qreal yRadius, const QColor &sc, qreal radius, const QPoint &offset);
 void drawShadow(QPainter *pa, const QRect &rect, const QPainterPath &path, const QColor &sc, int radius, const QPoint &offset);
+void drawInsetShadow(QPainter *pa, const QRect &rect, qreal xRadius, qreal yRadius, const QColor &sc, qreal radius, const QPoint &offset);
 void drawRoundedRect(QPainter *pa, const QRect &rect, qreal xRadius, qreal yRadius, Corners corners, Qt::SizeMode mode = Qt::AbsoluteSize);
 void drawFork(QPainter *pa, const QRectF &rect, const QColor &color, int width = 2);
 void drawMark(QPainter *pa, const QRectF &rect, const QColor &boxInside, const QColor &boxOutside, const int penWidth, const int outLineLeng = 2);

--- a/src/widgets/dstyle.cpp
+++ b/src/widgets/dstyle.cpp
@@ -392,6 +392,61 @@ void drawShadow(QPainter *pa, const QRect &rect, const QPainterPath &path, const
     pa->drawPixmap(shadow_rect, shadow);
 }
 
+void drawInsetShadow(QPainter *pa, const QRect &rect, qreal xRadius, qreal yRadius, const QColor &sc, qreal radius, const QPoint &offset)
+{
+    if (radius <= 0 || rect.isNull())
+        return;
+
+    qreal scale = pa->paintEngine()->paintDevice()->devicePixelRatioF();
+    QSize size = rect.size() * scale;
+    xRadius *= scale;
+    yRadius *= scale;
+    radius *= scale;
+    QPoint scaledOffset(offset.x() * scale, offset.y() * scale);
+
+    // Build an opaque image, then cut out a rounded-rect hole shifted by
+    // 'offset'. After blurring, the hole edges fade inward, producing an
+    // inset shadow. Positive offset.y() makes the shadow stronger at the
+    // top edge; negative at the bottom.
+    QImage shadow_base(size, QImage::Format_ARGB32_Premultiplied);
+    shadow_base.fill(Qt::black);
+
+    QPainter holePainter(&shadow_base);
+    holePainter.setRenderHint(QPainter::Antialiasing, true);
+    holePainter.setPen(Qt::NoPen);
+    holePainter.setCompositionMode(QPainter::CompositionMode_Clear);
+    holePainter.setBrush(Qt::transparent);
+    QRectF holeRect = QRectF(shadow_base.rect()).translated(scaledOffset);
+    holeRect = holeRect.marginsRemoved(QMarginsF(radius, radius, radius, radius));
+    holePainter.drawRoundedRect(holeRect, xRadius, yRadius);
+    holePainter.end();
+
+    // Blur the alpha channel so the hole edges become a soft gradient.
+    QImage blurred(size, QImage::Format_ARGB32_Premultiplied);
+    blurred.fill(0);
+    QPainter blurPainter(&blurred);
+    qt_blurImage(&blurPainter, shadow_base, radius, false, true);
+    blurPainter.end();
+
+    // Replace the placeholder black with the actual shadow color.
+    QPainter colorPainter(&blurred);
+    colorPainter.setCompositionMode(QPainter::CompositionMode_SourceIn);
+    colorPainter.fillRect(blurred.rect(), sc);
+    colorPainter.end();
+
+    blurred.setDevicePixelRatio(scale);
+
+    // Clip to the rounded-rect shape so the opaque outer area is hidden;
+    // only the inward-fading shadow at the edges is visible.
+    pa->save();
+    pa->setRenderHint(QPainter::Antialiasing, true);
+    QPainterPath clipPath;
+    clipPath.addRoundedRect(rect, xRadius / scale, yRadius / scale);
+    pa->setClipPath(clipPath);
+    pa->drawImage(rect.topLeft(), blurred);
+    pa->restore();
+}
+
 void drawFork(QPainter *pa, const QRectF &rect, const QColor &color, int width)
 {
     QPen pen;


### PR DESCRIPTION
## Background

dtkdeclarative 的 PR [#672](https://github.com/linuxdeepin/dtkdeclarative/pull/672) 在 ToolButton 深色模式 hover 中使用了内阴影效果（`BoxInsetShadow`），该效果目前只在 QML 中有组件支持。为了保持 QWidget 和 QML 两端视觉一致，需要在 dtkwidget 中提供等价的内阴影绘制能力。

## Changes

在 `DDrawUtils` 命名空间中新增 `drawInsetShadow()` 函数，与现有的 `drawShadow()` 接口风格平行：

```cpp
void drawInsetShadow(QPainter *pa, const QRect &rect,
                     qreal xRadius, qreal yRadius,
                     const QColor &sc, qreal radius,
                     const QPoint &offset);
```

### 实现原理

1. 创建与目标区域同大小的图片，填充不透明黑色
2. 用 `CompositionMode_Clear` 挖出按 offset 偏移的圆角矩形孔
3. 调用 `qt_blurImage` 对 alpha 通道做高斯模糊（与 `drawShadow` 使用同一函数）
4. 用 `CompositionMode_SourceIn` 替换为实际阴影颜色
5. 用圆角矩形路径 clip 后绘制，隐藏外圈不透明区域

### 与 QML BoxInsetShadow 的对应

| QML BoxInsetShadow | DDrawUtils::drawInsetShadow |
|---|---|
| `cornerRadius` | `xRadius` / `yRadius` |
| `shadowColor` | `sc` |
| `shadowOffsetY: 1` (顶部高光) | `offset` = `(0, 1)` |
| `shadowOffsetY: -1` (底部暗角) | `offset` = `(0, -1)` |
| `shadowBlur` | `radius` |

## Files

| File | Change |
|------|--------|
| `include/widgets/dstyle.h` | 新增 `drawInsetShadow` 声明 |
| `src/widgets/dstyle.cpp` | 新增 `drawInsetShadow` 实现 |

## Summary by Sourcery

Add inset-shadow rendering support to DDrawUtils for consistent inner-shadow effects across QWidget and QML interfaces.

New Features:
- Add a QWidget drawing utility for rendering soft inset shadows with configurable corner radii, color, blur radius, and offset.

Enhancements:
- Align QWidget shadow rendering capabilities with the existing QML inset-shadow visual effect.